### PR TITLE
set CFLAGS = -std=gnu99

### DIFF
--- a/snmp/snmp.go
+++ b/snmp/snmp.go
@@ -8,6 +8,7 @@ https://developers.google.com/open-source/licenses/bsd
 package snmp
 
 /*
+#cgo CFLAGS: -std=gnu99
 #cgo LDFLAGS: -lnetsnmp
 #include <net-snmp/net-snmp-config.h>
 #include <net-snmp/net-snmp-includes.h>


### PR DESCRIPTION
I needed this to compile on Ubuntu 14.04 / go 1.4.2 (running on Raspberry Pi 2)
