### PR TITLE
Retry for util init robot account creation

### DIFF
--- a/gcp-connector-util/init.go
+++ b/gcp-connector-util/init.go
@@ -11,6 +11,8 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -218,15 +220,6 @@ func initRobotAccount(context *cli.Context, userClient *http.Client) (string, st
 	params := url.Values{}
 	params.Set("oauth_client_id", lib.DefaultConfig.GCPOAuthClientID)
 
-	url := fmt.Sprintf("%s%s?%s", lib.DefaultConfig.GCPBaseURL, "createrobot", params.Encode())
-	response, err := userClient.Get(url)
-	if err != nil {
-		log.Fatalln(err)
-	}
-	if response.StatusCode != http.StatusOK {
-		log.Fatalf("Failed to initialize robot account: %s\n", response.Status)
-	}
-
 	var robotInit struct {
 		Success  bool   `json:"success"`
 		Message  string `json:"message"`
@@ -234,11 +227,45 @@ func initRobotAccount(context *cli.Context, userClient *http.Client) (string, st
 		AuthCode string `json:"authorization_code"`
 	}
 
-	if err = json.NewDecoder(response.Body).Decode(&robotInit); err != nil {
-		log.Fatalln(err)
-	}
-	if !robotInit.Success {
-		log.Fatalf("Failed to initialize robot account: %s\n", robotInit.Message)
+	url := fmt.Sprintf("%s%s?%s", lib.DefaultConfig.GCPBaseURL, "createrobot", params.Encode())
+	var response *http.Response
+	attempt := 1
+	for {
+		message := "Initializing robot account"
+		if (attempt > 1) {
+			message += fmt.Sprintf(" (attempt %d)", attempt)
+			time.Sleep(5 * time.Second)
+
+			if (response != nil) {
+				// Clean up the response to enable connection re-use
+				io.Copy(ioutil.Discard, response.Body)
+				response.Body.Close()
+			}
+		}
+		log.Println(message)
+		attempt += 1
+
+		response, err := userClient.Get(url)
+		if err != nil {
+			log.Fatalln(err)
+		}
+		
+		if response.StatusCode != http.StatusOK {
+			if response.StatusCode == 500 {
+				log.Println("The server seems busy. Retrying ...")
+				continue;
+			} else {
+				log.Fatalf("Failed to initialize robot account: %s\n", response.Status)
+			}
+		}
+
+		if err = json.NewDecoder(response.Body).Decode(&robotInit); err != nil {
+			log.Fatalln(err)
+		}
+		if !robotInit.Success {
+			log.Fatalf("Failed to initialize robot account: %s\n", robotInit.Message)
+		}
+		break;
 	}
 
 	return robotInit.XMPPJID, robotInit.AuthCode

--- a/gcp-connector-util/init.go
+++ b/gcp-connector-util/init.go
@@ -219,6 +219,7 @@ func getUserClientFromToken(context *cli.Context) *http.Client {
 func initRobotAccount(context *cli.Context, userClient *http.Client) (string, string) {
 	params := url.Values{}
 	params.Set("oauth_client_id", lib.DefaultConfig.GCPOAuthClientID)
+	url := fmt.Sprintf("%s%s?%s", lib.DefaultConfig.GCPBaseURL, "createrobot", params.Encode())
 
 	var robotInit struct {
 		Success  bool   `json:"success"`
@@ -227,7 +228,6 @@ func initRobotAccount(context *cli.Context, userClient *http.Client) (string, st
 		AuthCode string `json:"authorization_code"`
 	}
 
-	url := fmt.Sprintf("%s%s?%s", lib.DefaultConfig.GCPBaseURL, "createrobot", params.Encode())
 	var response *http.Response
 	attempt := 1
 	for {


### PR DESCRIPTION
A work-around for the gcp-connector-util init server error in issue #206:
Failed to initialize robot account: 500 Internal Server Error

This definitely works - tested over 20 times.

Here's a typical run:
Visit https://www.google.com/device, and enter this code. I'll wait for you.
LJSK-DJFV
Initializing robot account
The server seems busy. Retrying ...
Initializing robot account (attempt 2)
Acquired OAuth credentials for robot account

Notes:
- It only retries on the specific 500 status code failure, but other failure retries can quickly be added
- For simplicity it retries forever (until Ctrl-C) but I've never seen it take more than 3 attempts
- The Response clean-up might be overkill, but it guards against copy-and-paste bugs (and I learnt something)
