### PR TITLE
Initial renaming from google/cups-connector to google/cloud-print-connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Introduction
 Share printers from your Windows, Linux, FreeBSD or OS X computer with ChromeOS and Android devices, using the Cloud Print Connector. The Connector is a purpose-built system process. It can share hundreds of printers on a powerful server, or one printer on a Raspberry Pi.
 
-Lots of help can be found in [the wiki](https://github.com/google/cups-connector/wiki).
+Lots of help can be found in [the wiki](https://github.com/google/cloud-print-connector/wiki).
 
 ## Mailing list
 Please join the mailing list at https://groups.google.com/forum/#!forum/cloud-print-connector. Anyone can post and view messages.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Please join the mailing list at https://groups.google.com/forum/#!forum/cloud-pr
 ## Build Status
 * Linux/OSX: [![Build Status](https://travis-ci.org/google/cloud-print-connector.svg?branch=master)](https://travis-ci.org/google/cloud-print-connector)
 
-* FreeBSD: [![Build Status](http://jenkins.mouf.net/job/cups-connector/badge/icon)](http://jenkins.mouf.net/job/cups-connector/)
+* FreeBSD: [![Build Status](http://jenkins.mouf.net/job/cloud-print-connector/badge/icon)](http://jenkins.mouf.net/job/cloud-print-connector/)
 
 ## License
 Copyright 2015 Google Inc. All rights reserved.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Lots of help can be found in [the wiki](https://github.com/google/cloud-print-co
 Please join the mailing list at https://groups.google.com/forum/#!forum/cloud-print-connector. Anyone can post and view messages.
 
 ## Build Status
-* Linux/OSX: [![Build Status](https://travis-ci.org/google/cups-connector.svg?branch=master)](https://travis-ci.org/google/cups-connector)
+* Linux/OSX: [![Build Status](https://travis-ci.org/google/cloud-print-connector.svg?branch=master)](https://travis-ci.org/google/cloud-print-connector)
 
 * FreeBSD: [![Build Status](http://jenkins.mouf.net/job/cups-connector/badge/icon)](http://jenkins.mouf.net/job/cups-connector/)
 

--- a/lib/config.go
+++ b/lib/config.go
@@ -22,7 +22,7 @@ const (
 	ConnectorName = "Cloud Print Connector"
 
 	// A website with user-friendly information.
-	ConnectorHomeURL = "https://github.com/google/cups-connector"
+	ConnectorHomeURL = "https://github.com/google/cloud-print-connector"
 
 	GCPAPIVersion = "2.0"
 )


### PR DESCRIPTION
For issue #241. We still need to do a big rename of imports, but it should work ok for now.