### PR TITLE
Add printer whitelist

### DIFF
--- a/gcp-connector-util/main_unix.go
+++ b/gcp-connector-util/main_unix.go
@@ -136,6 +136,7 @@ func createCloudConfig(context *cli.Context, xmppJID, robotRefreshToken, userRef
 		PrefixJobIDToJobTitle:     lib.PointerToBool(context.Bool("prefix-job-id-to-job-title")),
 		DisplayNamePrefix:         context.String("display-name-prefix"),
 		PrinterBlacklist:          lib.DefaultConfig.PrinterBlacklist,
+		PrinterWhitelist:          lib.DefaultConfig.PrinterWhitelist,
 		LogLevel:                  context.String("log-level"),
 
 		LocalPortLow:  uint16(context.Int("local-port-low")),
@@ -167,6 +168,7 @@ func createLocalConfig(context *cli.Context) *lib.Config {
 		PrefixJobIDToJobTitle:     lib.PointerToBool(context.Bool("prefix-job-id-to-job-title")),
 		DisplayNamePrefix:         context.String("display-name-prefix"),
 		PrinterBlacklist:          lib.DefaultConfig.PrinterBlacklist,
+		PrinterWhitelist:          lib.DefaultConfig.PrinterWhitelist,
 		LogLevel:                  context.String("log-level"),
 
 		LocalPortLow:  uint16(context.Int("local-port-low")),

--- a/gcp-connector-util/main_windows.go
+++ b/gcp-connector-util/main_windows.go
@@ -225,6 +225,7 @@ func createCloudConfig(context *cli.Context, xmppJID, robotRefreshToken, userRef
 		PrefixJobIDToJobTitle:     lib.PointerToBool(context.Bool("prefix-job-id-to-job-title")),
 		DisplayNamePrefix:         context.String("display-name-prefix"),
 		PrinterBlacklist:          lib.DefaultConfig.PrinterBlacklist,
+		PrinterWhitelist:          lib.DefaultConfig.PrinterWhitelist,
 		LogLevel:                  context.String("log-level"),
 
 		LocalPortLow:  uint16(context.Int("local-port-low")),
@@ -244,6 +245,7 @@ func createLocalConfig(context *cli.Context) *lib.Config {
 		PrefixJobIDToJobTitle:     lib.PointerToBool(context.Bool("prefix-job-id-to-job-title")),
 		DisplayNamePrefix:         context.String("display-name-prefix"),
 		PrinterBlacklist:          lib.DefaultConfig.PrinterBlacklist,
+		PrinterWhitelist:          lib.DefaultConfig.PrinterWhitelist,
 		LogLevel:                  context.String("log-level"),
 
 		LocalPortLow:  uint16(context.Int("local-port-low")),

--- a/gcp-cups-connector/gcp-cups-connector.go
+++ b/gcp-cups-connector/gcp-cups-connector.go
@@ -156,7 +156,7 @@ func connector(context *cli.Context) int {
 	}
 	c, err := cups.NewCUPS(*config.CUPSCopyPrinterInfoToDisplayName, *config.PrefixJobIDToJobTitle,
 		config.DisplayNamePrefix, config.CUPSPrinterAttributes, config.CUPSMaxConnections,
-		cupsConnectTimeout, config.PrinterBlacklist, *config.CUPSIgnoreRawPrinters,
+		cupsConnectTimeout, config.PrinterBlacklist, config.PrinterWhitelist, *config.CUPSIgnoreRawPrinters,
 		*config.CUPSIgnoreClassPrinters)
 	if err != nil {
 		log.Fatal(err)

--- a/gcp-windows-connector/gcp-windows-connector.go
+++ b/gcp-windows-connector/gcp-windows-connector.go
@@ -149,7 +149,7 @@ func (service *service) Execute(args []string, r <-chan svc.ChangeRequest, s cha
 		defer x.Quit()
 	}
 
-	ws, err := winspool.NewWinSpool(*config.PrefixJobIDToJobTitle, config.DisplayNamePrefix, config.PrinterBlacklist)
+	ws, err := winspool.NewWinSpool(*config.PrefixJobIDToJobTitle, config.DisplayNamePrefix, config.PrinterBlacklist, config.PrinterWhitelist)
 	if err != nil {
 		log.Fatal(err)
 		return false, 1

--- a/lib/config.go
+++ b/lib/config.go
@@ -211,6 +211,9 @@ func (c *Config) commonBackfill(configMap map[string]interface{}) *Config {
 	if _, exists := configMap["printer_blacklist"]; !exists {
 		b.PrinterBlacklist = DefaultConfig.PrinterBlacklist
 	}
+	if _, exists := configMap["printer_whitelist"]; !exists {
+		b.PrinterWhitelist = DefaultConfig.PrinterWhitelist
+	}
 	if _, exists := configMap["local_printing_enable"]; !exists {
 		b.LocalPrintingEnable = DefaultConfig.LocalPrintingEnable
 	}

--- a/lib/config_unix.go
+++ b/lib/config_unix.go
@@ -99,6 +99,9 @@ type Config struct {
 	// Ignore printers with native names.
 	PrinterBlacklist []string `json:"printer_blacklist,omitempty"`
 
+	// Allow printers with native names.
+	PrinterWhitelist []string `json:"printer_whitelist,omitempty"`
+
 	// Least severity to log.
 	LogLevel string `json:"log_level"`
 
@@ -166,6 +169,7 @@ var DefaultConfig = Config{
 	PrefixJobIDToJobTitle:     PointerToBool(false),
 	DisplayNamePrefix:         "",
 	PrinterBlacklist:          []string{},
+	PrinterWhitelist:          []string{},
 	LogLevel:                  "INFO",
 
 	LocalPortLow:  26000,

--- a/lib/config_windows.go
+++ b/lib/config_windows.go
@@ -97,6 +97,9 @@ type Config struct {
 	// Ignore printers with native names.
 	PrinterBlacklist []string `json:"printer_blacklist,omitempty"`
 
+	// Allow printers with native names.
+	PrinterWhitelist []string `json:"printer_whitelist,omitempty"`
+
 	// Least severity to log.
 	LogLevel string `json:"log_level"`
 
@@ -133,6 +136,7 @@ var DefaultConfig = Config{
 		"Microsoft XPS Document Writer",
 		"Google Cloud Printer",
 	},
+	PrinterWhitelist:          []string{},
 	LocalPrintingEnable: true,
 	CloudPrintingEnable: false,
 	LogLevel:            "INFO",

--- a/lib/printer.go
+++ b/lib/printer.go
@@ -246,6 +246,28 @@ func FilterRawPrinters(printers []Printer) ([]Printer, []Printer) {
 	return notRaw, raw
 }
 
+func FilterBlacklistPrinters(printers []Printer, list map[string]interface{}) []Printer {
+	return filterPrinters(printers, list, false)
+}
+
+func FilterWhitelistPrinters(printers []Printer, list map[string]interface{}) []Printer {
+	if len(list) == 0 {
+		return printers; // Empty whitelist means don't use whitelist
+	}
+
+	return filterPrinters(printers, list, true)
+}
+
+func filterPrinters(printers []Printer, list map[string]interface{}, isWhitelist bool) []Printer {
+	result := make([]Printer, 0, len(printers))
+	for i := range printers {
+		if _, exists := list[printers[i].Name]; exists == isWhitelist {
+			result = append(result, printers[i])
+		}
+	}
+	return result
+}
+
 func PrinterIsRaw(printer Printer) bool {
 	if printer.Tags["printer-make-and-model"] == "Local Raw Printer" {
 		return true

--- a/lib/printer.go
+++ b/lib/printer.go
@@ -233,19 +233,6 @@ func diffPrinter(pn, pg *Printer) PrinterDiff {
 	}
 }
 
-// FilterRawPrinters splits a slice of printers into non-raw and raw.
-func FilterRawPrinters(printers []Printer) ([]Printer, []Printer) {
-	notRaw, raw := make([]Printer, 0, len(printers)), make([]Printer, 0, 0)
-	for i := range printers {
-		if PrinterIsRaw(printers[i]) {
-			raw = append(raw, printers[i])
-		} else {
-			notRaw = append(notRaw, printers[i])
-		}
-	}
-	return notRaw, raw
-}
-
 func FilterBlacklistPrinters(printers []Printer, list map[string]interface{}) []Printer {
 	return filterPrinters(printers, list, false)
 }
@@ -266,6 +253,19 @@ func filterPrinters(printers []Printer, list map[string]interface{}, isWhitelist
 		}
 	}
 	return result
+}
+
+// FilterRawPrinters splits a slice of printers into non-raw and raw.
+func FilterRawPrinters(printers []Printer) ([]Printer, []Printer) {
+	notRaw, raw := make([]Printer, 0, len(printers)), make([]Printer, 0, 0)
+	for i := range printers {
+		if PrinterIsRaw(printers[i]) {
+			raw = append(raw, printers[i])
+		} else {
+			notRaw = append(notRaw, printers[i])
+		}
+	}
+	return notRaw, raw
 }
 
 func PrinterIsRaw(printer Printer) bool {

--- a/lib/printer_test.go
+++ b/lib/printer_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2016 Google Inc. All rights reserved.
+
+Use of this source code is governed by a BSD-style
+license that can be found in the LICENSE file or at
+https://developers.google.com/open-source/licenses/bsd
+*/
+
+package lib
+
+import (
+	"testing"
+	"reflect"
+)
+
+func TestFilterBlacklistPrinters(t *testing.T) {
+	printers := []Printer {
+		{Name: "Stay1"},
+		{Name: "Go1"},
+		{Name: "Go2"},
+		{Name: "Stay2"},
+	}
+	blacklist := map[string]interface{} {
+		"Go1": "",
+		"Go2": "",
+	}
+	correctFilteredPrinters := []Printer {
+		{Name: "Stay1"},
+		{Name: "Stay2"},
+	}
+
+	filteredPrinters := FilterBlacklistPrinters(printers, blacklist)
+
+	if !reflect.DeepEqual(filteredPrinters, correctFilteredPrinters) {
+		t.Fatalf("filtering result incorrect: %v", filteredPrinters)
+	}
+}
+
+func TestFilterWhitelistPrinters(t *testing.T) {
+	printers := []Printer {
+		{Name: "Stay1"},
+		{Name: "Go1"},
+		{Name: "Go2"},
+		{Name: "Stay2"},
+	}
+	whitelist := map[string]interface{} {
+		"Stay1": "",
+		"Stay2": "",
+	}
+	correctFilteredPrinters := []Printer {
+		{Name: "Stay1"},
+		{Name: "Stay2"},
+	}
+
+	filteredPrinters := FilterWhitelistPrinters(printers, whitelist)
+
+	if !reflect.DeepEqual(filteredPrinters, correctFilteredPrinters) {
+		t.Fatalf("filtering result incorrect: %v", filteredPrinters)
+	}
+}


### PR DESCRIPTION
- Based on existing blacklist code regions.
- If the whitelist is empty then it is disabled.
- The blacklist overrides the whitelist.

The filterBlacklistPrinters function was duplicated in cups.go and
winspool.go, so instead of creating two more almost identical
filterWhitelistPrinters functions I factored out the common code in
lib/printer.go.