### PR TITLE
Implement Privet on Windows fixes #246

### DIFF
--- a/gcp-connector-util/init.go
+++ b/gcp-connector-util/init.go
@@ -16,7 +16,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"time"
 
@@ -352,10 +351,7 @@ func initConfigFile(context *cli.Context) error {
 	var err error
 
 	var localEnable bool
-	if runtime.GOOS == "windows" {
-		// Remove this if block when Privet support is added to Windows.
-		localEnable = false
-	} else if context.IsSet("local-printing-enable") {
+	if context.IsSet("local-printing-enable") {
 		localEnable = context.Bool("local-printing-enable")
 	} else {
 		fmt.Println("\"Local printing\" means that clients print directly to the connector via")
@@ -367,10 +363,7 @@ func initConfigFile(context *cli.Context) error {
 	}
 
 	var cloudEnable bool
-	if runtime.GOOS == "windows" {
-		// Remove this if block when Privet support is added to Windows.
-		cloudEnable = true
-	} else if localEnable == false {
+	if localEnable == false {
 		cloudEnable = true
 	} else if context.IsSet("cloud-printing-enable") {
 		cloudEnable = context.Bool("cloud-printing-enable")

--- a/privet/windows.go
+++ b/privet/windows.go
@@ -9,25 +9,104 @@
 package privet
 
 import (
-	"errors"
+  "fmt"
+  "sync"
+  "github.com/andrewtj/dnssd"
+  "github.com/google/cloud-print-connector/log"
 )
 
-type zeroconf struct{}
+const serviceType = "_privet._tcp"
 
-func newZeroconf() (*zeroconf, error) {
-	return nil, errors.New("Privet has not been implemented for Windows")
+type zeroconf struct {
+	printers map[string]dnssd.RegisterOp
+	pMutex   sync.RWMutex // Protects printers.
 }
 
+func newZeroconf() (*zeroconf, error) {
+	z := zeroconf{
+		printers: make(map[string]dnssd.RegisterOp),
+	}
+	return &z, nil
+}
+
+func nullDNSSDRegisterCallback(_ *dnssd.RegisterOp, _ error, _ bool, _, _, _ string) {}
+
 func (z *zeroconf) addPrinter(name string, port uint16, ty, note, url, id string, online bool) error {
+  z.pMutex.RLock()
+	if _, exists := z.printers[name]; exists {
+		z.pMutex.RUnlock()
+		return fmt.Errorf("Bonjour already has printer %s", name)
+	}
+	z.pMutex.RUnlock()
+
+  op := dnssd.NewRegisterOp(name, serviceType, int(port), nullDNSSDRegisterCallback)
+  op.SetTXTPair("ty", ty)
+  op.SetTXTPair("note", note)
+  op.SetTXTPair("url", url)
+  op.SetTXTPair("type", "printer")
+  op.SetTXTPair("id", id)
+  var cs string
+  if online {
+		cs = "online"
+  } else {
+		cs = "offline"
+	}
+  op.SetTXTPair("cs", cs)
+  err := op.Start()
+	if err != nil {
+		return err
+	}
+  z.pMutex.Lock()
+	defer z.pMutex.Unlock()
+
+	z.printers[name] = *op
 	return nil
 }
 
 func (z *zeroconf) updatePrinterTXT(name, ty, note, url, id string, online bool) error {
+  z.pMutex.RLock()
+	defer z.pMutex.RUnlock()
+
+	if op, exists := z.printers[name]; exists {
+		op.SetTXTPair("ty", ty)
+    op.SetTXTPair("note", note)
+    op.SetTXTPair("url", url)
+    op.SetTXTPair("type", "printer")
+    op.SetTXTPair("id", id)
+    var cs string
+    if online {
+		  cs = "online"
+    } else {
+		  cs = "offline"
+	  }
+    op.SetTXTPair("cs", cs)
+	} else {
+		return fmt.Errorf("Bonjour can't update printer %s that hasn't been added", name)
+	}
 	return nil
 }
 
 func (z *zeroconf) removePrinter(name string) error {
+  z.pMutex.RLock()
+	defer z.pMutex.RUnlock()
+
+	if op, exists := z.printers[name]; exists {
+		op.Stop()
+    delete(z.printers, name)
+    log.Info("Unregistered %s with bonjour", name)
+	} else {
+		return fmt.Errorf("Bonjour can't remove printer %s that hasn't been added", name)
+	}
+
 	return nil
 }
 
-func (z *zeroconf) quit() {}
+func (z *zeroconf) quit() {
+	z.pMutex.Lock()
+	defer z.pMutex.Unlock()
+
+	for name, op := range z.printers {
+		op.Stop()
+		delete(z.printers, name)
+  }
+}

--- a/wix/windows-connector.wxs
+++ b/wix/windows-connector.wxs
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:fire="http://schemas.microsoft.com/wix/FirewallExtension">
   <Product
       Id="*"
       Name="Google Cloud Print Windows Connector"
@@ -82,6 +82,14 @@
           Remove="uninstall"
           Start="install"
           Stop="uninstall" />
+			<fire:FirewallException
+			    Id="AllowConnectorTraffic"
+					Description="Allow Cloud Print Connector Inbound Network Traffic"
+					Name="Cloud Print Connector"
+					Profile="public"
+					Program="[#Connector_exe]"
+					Scope="any">
+			</fire:FirewallException>
       </Component>
       <Component Id="Connector_Util_exe">
         <File Id="ConnectorUtil" Name="gcp-connector-util.exe" KeyPath="yes" />


### PR DESCRIPTION
First shot at Privet on Windows for local printing. Code needs a lot of
work but on my test machine, local printing seems to work for basic
scenarios.

This patch uses github.com/andrewtj/dnssd for mDNS which in turn relies
on Apple's Bonjour Service for Windows which must be installed:

https://support.apple.com/kb/dl999?locale=en_US

Apple does allow Bonjour Service to be distrubuted in some cases so we
may be able to wrap it into the MSI installer but for now it will need
to be installed before cloud-print-connector.
