### PR TITLE
Generate a v4 UUID for proxy name instead of asking user fixes #295

### DIFF
--- a/gcp-connector-util/init.go
+++ b/gcp-connector-util/init.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/cloud-print-connector/gcp"
 	"github.com/google/cloud-print-connector/lib"
 	"github.com/urfave/cli"
+  "github.com/satori/go.uuid"
 
 	"golang.org/x/oauth2"
 )
@@ -401,10 +402,7 @@ func initConfigFile(context *cli.Context) error {
 		if context.IsSet("proxy-name") {
 			proxyName = context.String("proxy-name")
 		} else {
-			proxyName, err = scanNonEmptyString("Proxy name for this connector:")
-			if err != nil {
-				return err
-			}
+			proxyName = uuid.NewV4().String()
 		}
 
 		var userClient *http.Client

--- a/gcp-connector-util/init.go
+++ b/gcp-connector-util/init.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/google/cloud-print-connector/gcp"
 	"github.com/google/cloud-print-connector/lib"
+	"github.com/satori/go.uuid"
 	"github.com/urfave/cli"
-  "github.com/satori/go.uuid"
 
 	"golang.org/x/oauth2"
 )


### PR DESCRIPTION
Don't ask the user to enter a name for the proxy since the name is not
significant in most cases and may confuse user. If needed, user can
still set proxy name by running:

gcp-connector-util init --proxy-name mypreferred-name