### PR TITLE
Fix issues with MSI install with temp folder being different between UI and execute sequences

### DIFF
--- a/wix/windows-connector.wxs
+++ b/wix/windows-connector.wxs
@@ -105,7 +105,7 @@
           Delete="yes"
           DestinationDirectory="CloudPrintDataFolder"
           DestinationName="gcp-windows-connector.config.json"
-          SourceProperty="ConfigFile" />
+          SourceProperty="CONFIGFILEPATH" />
       <RemoveFile
           Id="ConfigFile"
           Directory="CloudPrintDataFolder"
@@ -114,18 +114,18 @@
     </Component>
     <Property Id="CONFIGFILE" Secure="yes" />
     <SetProperty
-        Id="ConfigFile"
+        Id="CONFIGFILEPATH"
         Action="SetConfigFileDefault"
         After="LaunchConditions"
-        Sequence="both"
+        Sequence="first"
         Value="[TempFolder]gcp-windows-connector.config.json">
       NOT CONFIGFILE
     </SetProperty>
     <SetProperty
-        Id="ConfigFile"
+        Id="CONFIGFILEPATH"
         Action="SetConfigFileCustom"
         After="LaunchConditions"
-        Sequence="both"
+        Sequence="first"
         Value="[CONFIGFILE]">
       CONFIGFILE
     </SetProperty>


### PR DESCRIPTION
Change config file path property to be a public property so that it can be passed to execute sequence and is set only during the first sequence (when running with UI, this is the UI sequence).

Tested by installing when logged in as a non-admin user, and elevating as a different admin user.  The config file is correctly copied from the non-admin user's temp folder even though the execute sequence runs as the admin user.

Resolves #316 