### PR TITLE
Use Trimspace() for universal whitespace removal

### DIFF
--- a/gcp-connector-util/init.go
+++ b/gcp-connector-util/init.go
@@ -312,7 +312,7 @@ func scanString(prompt string) (string, error) {
 	if answer, err := reader.ReadString('\n'); err != nil {
 		return "", err
 	} else {
-		answer = answer[:len(answer)-1] // remove newline
+		answer = strings.TrimSpace(answer) // remove newline
 		fmt.Println("")
 		return answer, nil
 	}


### PR DESCRIPTION
On Windows, pressing enter results in "\r" instead of "". Fix that by using TrimSpace to ensure all leading and trailing whitespace including \r and \n are removed.