### PR TITLE
pull MSI version from environment

### DIFF
--- a/wix/windows-connector.wxs
+++ b/wix/windows-connector.wxs
@@ -4,7 +4,7 @@
       Id="*"
       Name="Google Cloud Print Windows Connector"
       Language="1033"
-      Version="0.9.0"
+      Version="$(env.CONNECTOR_VERSION)"
       Manufacturer="Google, Inc."
       UpgradeCode="15C3FD61-B03C-4C04-A56D-CD8424C99D7F">
     <Package


### PR DESCRIPTION
Currently we don't have version / build numbers anywhere else in the source. Set WIX config to use a environment variable for MSI version also. With this change you can run:

export CONNECTOR_VERSION=0.9.1
/c/Program\ Files\ (x86)/WiX\ Toolset\ v3.10/bin/candle.exe -arch x64 windows-connector.wxs dependencies.wxs
/c/Program\ Files\ (x86)/WiX\ Toolset\ v3.10/bin/light.exe -ext "C:\Program Files (x86)\WiX Toolset v3.10\bin\WixUIExtension.dll" -ext WixfirewallExtension windows-connector.wixobj dependencies.wixobj -o windows-connector.msi

to dynamically set the MSI version number.
