### PR TITLE
include ppd.h

### DIFF
--- a/cups/cups.h
+++ b/cups/cups.h
@@ -12,6 +12,7 @@ https://developers.google.com/open-source/licenses/bsd
 #define _IPP_PRIVATE_STRUCTURES 1
 
 #include <cups/cups.h>
+#include <cups/ppd.h>
 #include <stddef.h>      // size_t
 #include <stdlib.h>      // free, calloc, malloc
 #include <sys/socket.h>  // AF_UNSPEC


### PR DESCRIPTION
CUPS 2.2+ moved CupsGetPPD3 from cups.h to ppd.h. Include both so we can compile against old and new version of CUPS.

See:

https://groups.google.com/d/msg/cloud-print-connector/I3P0ccKkXP8/54pPV5z9BQAJ

for details.