### PR TITLE
Provide additional workaround to issue #160

### DIFF
--- a/systemd/cloud-print-connector.service
+++ b/systemd/cloud-print-connector.service
@@ -15,5 +15,10 @@ ExecStart=/opt/cloud-print-connector/gcp-cups-connector -config-filename /opt/cl
 Restart=on-failure
 User=cloud-print-connector
 
+# Restart indefinitely to work around failure to start if network is down.
+# See https://github.com/google/cloud-print-connector/issues/160
+StartLimitInterval=0
+RestartSec=3
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
systemd by default will give up restarting a unit after 10 tries, waiting 100ms between retries.
See https://github.com/systemd/systemd/issues/2416.

This causes problems with the Cloud Print Connector because it fails on startup if the network
is down. To work around this problem, we let systemd restart the connector indefinitely.

Fixes #140.