### PR TITLE
Handle mDNS collisions in privet with Avahi

### DIFF
--- a/privet/avahi.c
+++ b/privet/avahi.c
@@ -61,9 +61,9 @@ static const char *populateGroup(AvahiClient *client, AvahiEntryGroup *group,
   return NULL;
 }
 
-const char *addAvahiGroup(AvahiClient *client, AvahiEntryGroup **group,
+const char *addAvahiGroup(AvahiClient *client, AvahiEntryGroup **group, const char *printer_name,
     const char *service_name, unsigned short port, AvahiStringList *txt) {
-  *group = avahi_entry_group_new(client, handleGroupStateChange, (void *)service_name);
+  *group = avahi_entry_group_new(client, handleGroupStateChange, (void *)printer_name);
   if (!*group) {
     return avahi_strerror(avahi_client_errno(client));
   }

--- a/privet/avahi.c
+++ b/privet/avahi.c
@@ -70,6 +70,12 @@ const char *addAvahiGroup(AvahiClient *client, AvahiEntryGroup **group,
   return populateGroup(client, *group, service_name, port, txt);
 }
 
+const char *resetAvahiGroup(AvahiClient *client, AvahiEntryGroup *group, const char *service_name,
+    unsigned short port, AvahiStringList *txt) {
+  avahi_entry_group_reset(group);
+  return populateGroup(client, group, service_name, port, txt);
+}
+
 const char *updateAvahiGroup(AvahiEntryGroup *group, const char *service_name, AvahiStringList *txt) {
   int error = avahi_entry_group_update_service_txt_strlst(group, AVAHI_IF_UNSPEC,
       AVAHI_PROTO_UNSPEC, 0, service_name, SERVICE_TYPE, NULL, txt);

--- a/privet/avahi.c
+++ b/privet/avahi.c
@@ -36,8 +36,8 @@ const char *startAvahiClient(AvahiThreadedPoll **threaded_poll, AvahiClient **cl
   return NULL;
 }
 
-const char *addAvahiGroup(AvahiThreadedPoll *threaded_poll, AvahiClient *client,
-    AvahiEntryGroup **group, const char *service_name, unsigned short port, AvahiStringList *txt) {
+const char *addAvahiGroup(AvahiClient *client, AvahiEntryGroup **group,
+    const char *service_name, unsigned short port, AvahiStringList *txt) {
   *group = avahi_entry_group_new(client, handleGroupStateChange, (void *)service_name);
   if (!*group) {
     return avahi_strerror(avahi_client_errno(client));
@@ -66,8 +66,7 @@ const char *addAvahiGroup(AvahiThreadedPoll *threaded_poll, AvahiClient *client,
   return NULL;
 }
 
-const char *updateAvahiGroup(AvahiThreadedPoll *threaded_poll, AvahiEntryGroup *group,
-    const char *service_name, AvahiStringList *txt) {
+const char *updateAvahiGroup(AvahiEntryGroup *group, const char *service_name, AvahiStringList *txt) {
   int error = avahi_entry_group_update_service_txt_strlst(group, AVAHI_IF_UNSPEC,
       AVAHI_PROTO_UNSPEC, 0, service_name, SERVICE_TYPE, NULL, txt);
   if (AVAHI_OK != error) {
@@ -76,7 +75,7 @@ const char *updateAvahiGroup(AvahiThreadedPoll *threaded_poll, AvahiEntryGroup *
   return NULL;
 }
 
-const char *removeAvahiGroup(AvahiThreadedPoll *threaded_poll, AvahiEntryGroup *group) {
+const char *removeAvahiGroup(AvahiEntryGroup *group) {
   int error = avahi_entry_group_free(group);
   if (AVAHI_OK != error) {
     return avahi_strerror(error);

--- a/privet/avahi.go
+++ b/privet/avahi.go
@@ -139,7 +139,7 @@ func (z *zeroconf) addPrinter(name string, port uint16, ty, note, url, id string
 		C.avahi_threaded_poll_lock(z.threadedPoll)
 		defer C.avahi_threaded_poll_unlock(z.threadedPoll)
 
-		if errstr := C.addAvahiGroup(z.client, &r.group, r.name, C.ushort(r.port), txt); errstr != nil {
+		if errstr := C.addAvahiGroup(z.client, &r.group, r.name, r.name, C.ushort(r.port), txt); errstr != nil {
 			err := fmt.Errorf("Failed to add Avahi group: %s", C.GoString(errstr))
 			return err
 		}
@@ -274,7 +274,7 @@ func handleClientStateChange(client *C.AvahiClient, newState C.AvahiClientState,
 			txt := prepareTXT(r.ty, r.note, r.url, r.id, r.online)
 			defer C.avahi_string_list_free(txt)
 
-			if errstr := C.addAvahiGroup(z.client, &r.group, r.name, C.ushort(r.port), txt); errstr != nil {
+			if errstr := C.addAvahiGroup(z.client, &r.group, r.name, r.name, C.ushort(r.port), txt); errstr != nil {
 				err := errors.New(C.GoString(errstr))
 				log.Errorf("Failed to add Avahi group: %s", err)
 			}

--- a/privet/avahi.go
+++ b/privet/avahi.go
@@ -139,7 +139,7 @@ func (z *zeroconf) addPrinter(name string, port uint16, ty, note, url, id string
 		C.avahi_threaded_poll_lock(z.threadedPoll)
 		defer C.avahi_threaded_poll_unlock(z.threadedPoll)
 
-		if errstr := C.addAvahiGroup(z.threadedPoll, z.client, &r.group, r.name, C.ushort(r.port), txt); errstr != nil {
+		if errstr := C.addAvahiGroup(z.client, &r.group, r.name, C.ushort(r.port), txt); errstr != nil {
 			err := fmt.Errorf("Failed to add Avahi group: %s", C.GoString(errstr))
 			return err
 		}
@@ -170,7 +170,7 @@ func (z *zeroconf) updatePrinterTXT(name, ty, note, url, id string, online bool)
 		C.avahi_threaded_poll_lock(z.threadedPoll)
 		defer C.avahi_threaded_poll_unlock(z.threadedPoll)
 
-		if errstr := C.updateAvahiGroup(z.threadedPoll, r.group, r.name, txt); errstr != nil {
+		if errstr := C.updateAvahiGroup(r.group, r.name, txt); errstr != nil {
 			err := fmt.Errorf("Failed to update Avahi group: %s", C.GoString(errstr))
 			return err
 		}
@@ -193,7 +193,7 @@ func (z *zeroconf) removePrinter(name string) error {
 		C.avahi_threaded_poll_lock(z.threadedPoll)
 		defer C.avahi_threaded_poll_unlock(z.threadedPoll)
 
-		if errstr := C.removeAvahiGroup(z.threadedPoll, r.group); errstr != nil {
+		if errstr := C.removeAvahiGroup(r.group); errstr != nil {
 			err := fmt.Errorf("Failed to remove Avahi group: %s", C.GoString(errstr))
 			return err
 		}
@@ -257,7 +257,7 @@ func handleClientStateChange(client *C.AvahiClient, newState C.AvahiClientState,
 		log.Info("Local printing disabled (Avahi client is not running).")
 		for name, r := range z.printers {
 			if r.group != nil {
-				if errstr := C.removeAvahiGroup(z.threadedPoll, r.group); errstr != nil {
+				if errstr := C.removeAvahiGroup(r.group); errstr != nil {
 					err := errors.New(C.GoString(errstr))
 					log.Errorf("Failed to remove Avahi group: %s", err)
 				}
@@ -274,7 +274,7 @@ func handleClientStateChange(client *C.AvahiClient, newState C.AvahiClientState,
 			txt := prepareTXT(r.ty, r.note, r.url, r.id, r.online)
 			defer C.avahi_string_list_free(txt)
 
-			if errstr := C.addAvahiGroup(z.threadedPoll, z.client, &r.group, r.name, C.ushort(r.port), txt); errstr != nil {
+			if errstr := C.addAvahiGroup(z.client, &r.group, r.name, C.ushort(r.port), txt); errstr != nil {
 				err := errors.New(C.GoString(errstr))
 				log.Errorf("Failed to add Avahi group: %s", err)
 			}

--- a/privet/avahi.h
+++ b/privet/avahi.h
@@ -7,7 +7,9 @@
 // +build linux freebsd
 
 #include <avahi-client/publish.h>
+#include <avahi-common/alternative.h>
 #include <avahi-common/error.h>
+#include <avahi-common/malloc.h>
 #include <avahi-common/strlst.h>
 #include <avahi-common/thread-watch.h>
 

--- a/privet/avahi.h
+++ b/privet/avahi.h
@@ -15,7 +15,7 @@
 
 const char *startAvahiClient(AvahiThreadedPoll **threaded_poll, AvahiClient **client);
 const char *addAvahiGroup(AvahiClient *client, AvahiEntryGroup **group,
-    const char *serviceName, unsigned short port, AvahiStringList *txt);
-const char *updateAvahiGroup(AvahiEntryGroup *group, const char *serviceName, AvahiStringList *txt);
+    const char *service_name, unsigned short port, AvahiStringList *txt);
+const char *updateAvahiGroup(AvahiEntryGroup *group, const char *service_name, AvahiStringList *txt);
 const char *removeAvahiGroup(AvahiEntryGroup *group);
 void stopAvahiClient(AvahiThreadedPoll *threaded_poll, AvahiClient *client);

--- a/privet/avahi.h
+++ b/privet/avahi.h
@@ -14,9 +14,8 @@
 #include <stdlib.h> // free
 
 const char *startAvahiClient(AvahiThreadedPoll **threaded_poll, AvahiClient **client);
-const char *addAvahiGroup(AvahiThreadedPoll *threaded_poll, AvahiClient *client,
-    AvahiEntryGroup **group, const char *serviceName, unsigned short port, AvahiStringList *txt);
-const char *updateAvahiGroup(AvahiThreadedPoll *threaded_poll, AvahiEntryGroup *group,
-    const char *serviceName, AvahiStringList *txt);
-const char *removeAvahiGroup(AvahiThreadedPoll *threaded_poll, AvahiEntryGroup *group);
+const char *addAvahiGroup(AvahiClient *client, AvahiEntryGroup **group,
+    const char *serviceName, unsigned short port, AvahiStringList *txt);
+const char *updateAvahiGroup(AvahiEntryGroup *group, const char *serviceName, AvahiStringList *txt);
+const char *removeAvahiGroup(AvahiEntryGroup *group);
 void stopAvahiClient(AvahiThreadedPoll *threaded_poll, AvahiClient *client);

--- a/privet/avahi.h
+++ b/privet/avahi.h
@@ -16,6 +16,8 @@
 const char *startAvahiClient(AvahiThreadedPoll **threaded_poll, AvahiClient **client);
 const char *addAvahiGroup(AvahiClient *client, AvahiEntryGroup **group,
     const char *service_name, unsigned short port, AvahiStringList *txt);
+const char *resetAvahiGroup(AvahiClient *client, AvahiEntryGroup *group, const char *service_name,
+    unsigned short port, AvahiStringList *txt);
 const char *updateAvahiGroup(AvahiEntryGroup *group, const char *service_name, AvahiStringList *txt);
 const char *removeAvahiGroup(AvahiEntryGroup *group);
 void stopAvahiClient(AvahiThreadedPoll *threaded_poll, AvahiClient *client);

--- a/privet/avahi.h
+++ b/privet/avahi.h
@@ -14,7 +14,7 @@
 #include <stdlib.h> // free
 
 const char *startAvahiClient(AvahiThreadedPoll **threaded_poll, AvahiClient **client);
-const char *addAvahiGroup(AvahiClient *client, AvahiEntryGroup **group,
+const char *addAvahiGroup(AvahiClient *client, AvahiEntryGroup **group, const char *printer_name,
     const char *service_name, unsigned short port, AvahiStringList *txt);
 const char *resetAvahiGroup(AvahiClient *client, AvahiEntryGroup *group, const char *service_name,
     unsigned short port, AvahiStringList *txt);


### PR DESCRIPTION
Avahi makes it a bit tricky to handle service name collisions,
so it was not implemented before. Now multiple printers with
the same name can be registered on the same local network. This
comes up in the case where a privet-enabled printer is also
connected with the Cloud Print Connector.

Fixes #342.