### PR TITLE
Add Firebase Messaging capabilities to connector.

### DIFF
--- a/fcm/fcm.go
+++ b/fcm/fcm.go
@@ -1,0 +1,200 @@
+package fcm
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+import (
+	"github.com/google/cloud-print-connector/log"
+	"github.com/google/cloud-print-connector/notification"
+)
+
+const (
+	gcpFcmSubscribePath = "fcm/subscribe"
+)
+
+type FCM struct {
+	fcmServerBindURL string
+	cachedToken      string
+	tokenRefreshTime time.Time
+	clientID         string
+	proxyName        string
+	fcmTTLSecs       float64
+	FcmSubscribe     func(string) (interface{}, error)
+
+	notifications chan<- notification.PrinterNotification
+	dead          chan struct{}
+
+	quit chan struct{}
+}
+
+type FCMMessage []struct {
+	From        string `json:"from"`
+	Category    string `json:"category"`
+	CollapseKey string `json:"collapse_key"`
+	Data struct {
+		Notification string `json:"notification"`
+		Subtype      string `json:"subtype"`
+	} `json:"data"`
+	MessageID  string `json:"message_id"`
+	TimeToLive int    `json:"time_to_live"`
+}
+
+func NewFCM(clientID string, proxyName string, fcmServerBindURL string, FcmSubscribe func(string) (interface{}, error), notifications chan<- notification.PrinterNotification) (*FCM, error) {
+	f := FCM{
+		fcmServerBindURL,
+		"",
+		time.Time{},
+		clientID,
+		proxyName,
+		0,
+		FcmSubscribe,
+		notifications,
+		make(chan struct{}),
+		make(chan struct{}),
+	}
+	return &f, nil
+}
+
+//  get token from GCP and connect to FCM.
+func (f *FCM) Init() {
+	iidToken := f.GetTokenWithRetry()
+	if err := f.ConnectToFcm(f.notifications, iidToken, f.dead, f.quit); err != nil {
+		for err != nil {
+			log.Errorf("FCM restart failed, will try again in 10s: %s", err)
+			time.Sleep(10 * time.Second)
+			err = f.ConnectToFcm(f.notifications, iidToken, f.dead, f.quit)
+		}
+		log.Info("FCM conversation restarted successfully")
+	}
+
+	go f.KeepFcmAlive()
+}
+
+// Quit terminates the FCM conversation so that new jobs stop arriving.
+func (f *FCM) Quit() {
+	// Signal to KeepFCMAlive.
+	close(f.quit)
+}
+
+// Fcm notification listener
+func (f *FCM) ConnectToFcm(fcmNotifications chan<- notification.PrinterNotification, iidToken string, dead chan<- struct{}, quit chan<- struct{}) error {
+	log.Debugf("Connecting to %s?token=%s", f.fcmServerBindURL, iidToken)
+	resp, err := http.Get(fmt.Sprintf("%s?token=%s", f.fcmServerBindURL, iidToken))
+	if err != nil {
+		// failed for ever no need to retry
+		log.Errorf("%v", err)
+		quit <- struct{}{}
+		return err
+	}
+	if resp.StatusCode == 200 {
+		reader := bufio.NewReader(resp.Body)
+		go func() {
+			for {
+				printerId, err := GetPrinterID(reader)
+				if len(printerId) > 0 {
+					pn := notification.PrinterNotification{printerId, notification.PrinterNewJobs}
+					fcmNotifications <- pn
+				}
+				if err != nil {
+						log.Info("DRAIN message received, client reconnecting.")
+						dead <- struct{}{}
+						break
+					}
+			}
+		}()
+	}
+	return nil
+}
+
+func GetPrinterID(reader *bufio.Reader) (string, error) {
+	raw_input, err := reader.ReadBytes('\n')
+	if err == nil {
+		// Trim last \n char
+		raw_input = raw_input[:len(raw_input) - 1]
+		buffer_size, _ := strconv.Atoi(string(raw_input))
+		notification_buffer := make([]byte, buffer_size)
+		var sofar, sz int
+		for err == nil && sofar < buffer_size {
+			sz, err = reader.Read(notification_buffer[sofar:])
+			sofar += sz
+		}
+
+		if sofar == buffer_size {
+			var d [][]interface{}
+			var f FCMMessage
+			json.Unmarshal([]byte(string(notification_buffer)), &d)
+			s, _ := json.Marshal(d[0][1])
+			json.Unmarshal(s, &f)
+			return f[0].Data.Notification, err
+		}
+	}
+	return "", err
+}
+
+// Restart FCM connection when lost.
+func (f *FCM) KeepFcmAlive() {
+	for {
+		select {
+		case <-f.dead:
+			iidToken := f.GetTokenWithRetry()
+			log.Error("FCM conversation died; restarting")
+			if err := f.ConnectToFcm(f.notifications, iidToken, f.dead, f.quit); err != nil {
+				for err != nil {
+					log.Errorf("FCM connection restart failed, will try again in 10s: %s", err)
+					time.Sleep(10 * time.Second)
+					err = f.ConnectToFcm(f.notifications, iidToken, f.dead, f.quit)
+				}
+				log.Info("FCM conversation restarted successfully")
+			}
+
+		case <-f.quit:
+			log.Info("Fcm client Quitting ...")
+			// quitting keeping alive
+			return
+		}
+	}
+}
+
+func (f *FCM) GetTokenWithRetry() string {
+	retryCount := 3
+	iidToken, err := f.GetToken()
+	for err != nil && retryCount < 3 {
+		retryCount -= 1
+		log.Errorf("unable to get FCM token from GCP server, will try again in 10s: %s", err)
+		time.Sleep(10 * time.Second)
+		iidToken, err = f.GetToken()
+	}
+	if err != nil {
+		log.Errorf("unable to get FCM token from GCP server.")
+		panic(err)
+	}
+	return iidToken
+}
+
+// Returns cached token and Refresh token if needed.
+func (f *FCM) GetToken() (string, error) {
+	if f.tokenRefreshTime == (time.Time{}) || time.Now().UTC().Sub(f.tokenRefreshTime).Seconds() > f.fcmTTLSecs {
+		result, err := f.FcmSubscribe(fmt.Sprintf("%s?client=%s&proxy=%s", gcpFcmSubscribePath, f.clientID, f.proxyName))
+		if err != nil {
+			log.Errorf("Unable to subscribe to FCM : %s", err)
+			return "", err
+		}
+		token := result.(map[string]interface{})["token"]
+		ttlSeconds, err := strconv.ParseFloat(result.(map[string]interface{})["fcmttl"].(string), 64)
+		if err != nil {
+			log.Errorf("Failed to parse FCM ttl  : %s", err)
+			return "", err
+		}
+		f.fcmTTLSecs = ttlSeconds
+		log.Info("Updated FCM token.")
+		f.cachedToken = token.(string)
+		f.tokenRefreshTime = time.Now().UTC()
+	}
+	return f.cachedToken, nil
+}

--- a/fcm/fcm_test.go
+++ b/fcm/fcm_test.go
@@ -1,0 +1,67 @@
+package fcm_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+import (
+	"github.com/google/cloud-print-connector/fcm"
+	"github.com/google/cloud-print-connector/notification"
+)
+
+func TestFCM_ReceiveNotification(t *testing.T) {
+
+	// test FCM server
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		printerNotificationStr :=
+				`148
+[[4,[{"from":"xyz","category":"js","collapse_key":"xyz","data":{"notification":"printerId","subtype":"xyz"},"message_id":"xyz","time_to_live":60}]]]`
+		fmt.Fprint(w, printerNotificationStr)
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(handler))
+	defer ts.Close()
+
+	var f *fcm.FCM
+	notifications := make(chan notification.PrinterNotification, 5)
+
+	// sample notification
+	var fcmToken map[string]interface{}
+	fcmTokenStr := `{"fcmttl":"2419200","request":{"params":{"client":["xyz"],"proxy":["xyz"]},"time":"0","user":"xyz","users":["xyz"]},"success":true,"token":"token","xsrf_token":"xyz"}`
+	json.Unmarshal([]byte(fcmTokenStr), &fcmToken)
+
+	f, err := fcm.NewFCM("clientid", "", ts.URL, func(input string) (interface{}, error) { return fcmToken, nil }, notifications)
+	defer f.Quit()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// This method is stubbed.
+	result, err := f.FcmSubscribe("SubscribeUrl")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	token := result.(map[string]interface{})["token"].(string)
+	dead := make(chan struct{})
+	quit := make(chan struct{})
+
+	// bind to FCM to receive notifications
+	f.ConnectToFcm(notifications, token, dead, quit)
+	go func() {
+		time.Sleep(4 * time.Second)
+		// time out
+		notifications <- notification.PrinterNotification{"dummy", notification.PrinterNewJobs}
+	}()
+	message := <-notifications
+
+	// verify if right message received.
+	if message.GCPID != "printerId" {
+		t.Fatal("Did not receive right printer notification")
+	}
+}

--- a/gcp-connector-util/gcp-cups-connector-util.go
+++ b/gcp-connector-util/gcp-cups-connector-util.go
@@ -174,7 +174,7 @@ func getGCP(config *lib.Config) (*gcp.GoogleCloudPrint, error) {
 	return gcp.NewGoogleCloudPrint(config.GCPBaseURL, config.RobotRefreshToken,
 		config.UserRefreshToken, config.ProxyName, config.GCPOAuthClientID,
 		config.GCPOAuthClientSecret, config.GCPOAuthAuthURL, config.GCPOAuthTokenURL,
-		0, nil)
+		0, nil, false)
 }
 
 // backfillConfigFile opens the config file, adds all missing keys

--- a/gcp-connector-util/main_unix.go
+++ b/gcp-connector-util/main_unix.go
@@ -116,6 +116,7 @@ func createCloudConfig(context *cli.Context, xmppJID, robotRefreshToken, userRef
 		UserRefreshToken:          userRefreshToken,
 		ShareScope:                shareScope,
 		ProxyName:                 proxyName,
+		FcmServerBindUrl:          context.String("fcm-server-bind-url"),
 		XMPPServer:                lib.DefaultConfig.XMPPServer,
 		XMPPPort:                  uint16(context.Int("xmpp-port")),
 		XMPPPingTimeout:           context.String("xmpp-ping-timeout"),

--- a/gcp-connector-util/main_windows.go
+++ b/gcp-connector-util/main_windows.go
@@ -196,6 +196,7 @@ func createCloudConfig(context *cli.Context, xmppJID, robotRefreshToken, userRef
 		UserRefreshToken:          userRefreshToken,
 		ShareScope:                shareScope,
 		ProxyName:                 proxyName,
+		FcmServerBindUrl:          context.String("fcm-server-bind-url"),
 		XMPPServer:                lib.DefaultConfig.XMPPServer,
 		XMPPPort:                  uint16(context.Int("xmpp-port")),
 		XMPPPingTimeout:           context.String("xmpp-ping-timeout"),

--- a/gcp-cups-connector/gcp-cups-connector.go
+++ b/gcp-cups-connector/gcp-cups-connector.go
@@ -20,11 +20,13 @@ import (
 
 	"github.com/coreos/go-systemd/journal"
 	"github.com/google/cloud-print-connector/cups"
+	"github.com/google/cloud-print-connector/fcm"
 	"github.com/google/cloud-print-connector/gcp"
 	"github.com/google/cloud-print-connector/lib"
 	"github.com/google/cloud-print-connector/log"
 	"github.com/google/cloud-print-connector/manager"
 	"github.com/google/cloud-print-connector/monitor"
+	"github.com/google/cloud-print-connector/notification"
 	"github.com/google/cloud-print-connector/privet"
 	"github.com/google/cloud-print-connector/xmpp"
 	"github.com/urfave/cli"
@@ -37,6 +39,7 @@ func main() {
 	app.Version = lib.BuildDate
 	app.Flags = []cli.Flag{
 		lib.ConfigFilenameFlag,
+		lib.UseFcm,
 		cli.BoolFlag{
 			Name:  "log-to-console",
 			Usage: "Log to STDERR, in addition to configured logging",
@@ -54,6 +57,7 @@ func connector(context *cli.Context) error {
 
 	logToJournal := *config.LogToJournal && journal.Enabled()
 	logToConsole := context.Bool("log-to-console")
+	useFcm := context.Bool("gcp-use-fcm")
 
 	if logToJournal {
 		log.SetJournalEnabled(true)
@@ -113,10 +117,11 @@ func connector(context *cli.Context) error {
 	}
 
 	jobs := make(chan *lib.Job, 10)
-	xmppNotifications := make(chan xmpp.PrinterNotification, 5)
+	notifications := make(chan notification.PrinterNotification, 5)
 
 	var g *gcp.GoogleCloudPrint
 	var x *xmpp.XMPP
+	var f *fcm.FCM
 	if config.CloudPrintingEnable {
 		xmppPingTimeout, err := time.ParseDuration(config.XMPPPingTimeout)
 		if err != nil {
@@ -134,19 +139,27 @@ func connector(context *cli.Context) error {
 		g, err = gcp.NewGoogleCloudPrint(config.GCPBaseURL, config.RobotRefreshToken,
 			config.UserRefreshToken, config.ProxyName, config.GCPOAuthClientID,
 			config.GCPOAuthClientSecret, config.GCPOAuthAuthURL, config.GCPOAuthTokenURL,
-			config.GCPMaxConcurrentDownloads, jobs)
+			config.GCPMaxConcurrentDownloads, jobs, useFcm)
 		if err != nil {
 			log.Fatal(err)
 			return cli.NewExitError(err.Error(), 1)
 		}
-
-		x, err = xmpp.NewXMPP(config.XMPPJID, config.ProxyName, config.XMPPServer, config.XMPPPort,
-			xmppPingTimeout, xmppPingInterval, g.GetRobotAccessToken, xmppNotifications)
-		if err != nil {
-			log.Fatal(err)
-			return cli.NewExitError(err.Error(), 1)
+		if useFcm {
+			f, err = fcm.NewFCM(config.GCPOAuthClientID, config.ProxyName, config.FcmServerBindUrl, g.FcmSubscribe, notifications)
+			if err != nil {
+				log.Fatal(err)
+				return cli.NewExitError(err.Error(), 1)
+			}
+			defer f.Quit()
+		} else {
+			x, err = xmpp.NewXMPP(config.XMPPJID, config.ProxyName, config.XMPPServer, config.XMPPPort,
+				xmppPingTimeout, xmppPingInterval, g.GetRobotAccessToken, notifications)
+			if err != nil {
+				log.Fatal(err)
+				return cli.NewExitError(err.Error(), 1)
+			}
+			defer x.Quit()
 		}
-		defer x.Quit()
 	}
 
 	cupsConnectTimeout, err := time.ParseDuration(config.CUPSConnectTimeout)
@@ -187,13 +200,17 @@ func connector(context *cli.Context) error {
 	}
 	pm, err := manager.NewPrinterManager(c, g, priv, nativePrinterPollInterval,
 		config.NativeJobQueueSize, *config.CUPSJobFullUsername, config.ShareScope,
-		jobs, xmppNotifications)
+		jobs, notifications)
 	if err != nil {
 		log.Fatal(err)
 		return cli.NewExitError(err.Error(), 1)
 	}
 	defer pm.Quit()
 
+	// Init FCM client after printers are registered
+	if useFcm && config.CloudPrintingEnable {
+		f.Init()
+	}
 	m, err := monitor.NewMonitor(c, g, priv, pm, config.MonitorSocketFilename)
 	if err != nil {
 		log.Fatal(err)

--- a/gcp/gcp.go
+++ b/gcp/gcp.go
@@ -50,13 +50,14 @@ type GoogleCloudPrint struct {
 	robotClient *http.Client
 	userClient  *http.Client
 	proxyName   string
+	useFcm      bool
 
 	jobs              chan<- *lib.Job
 	downloadSemaphore *lib.Semaphore
 }
 
 // NewGoogleCloudPrint establishes a connection with GCP, returns a new GoogleCloudPrint object.
-func NewGoogleCloudPrint(baseURL, robotRefreshToken, userRefreshToken, proxyName, oauthClientID, oauthClientSecret, oauthAuthURL, oauthTokenURL string, maxConcurrentDownload uint, jobs chan<- *lib.Job) (*GoogleCloudPrint, error) {
+func NewGoogleCloudPrint(baseURL, robotRefreshToken, userRefreshToken, proxyName, oauthClientID, oauthClientSecret, oauthAuthURL, oauthTokenURL string, maxConcurrentDownload uint, jobs chan<- *lib.Job, useFcm bool) (*GoogleCloudPrint, error) {
 	robotClient, err := newClient(oauthClientID, oauthClientSecret, oauthAuthURL, oauthTokenURL, robotRefreshToken, ScopeCloudPrint, ScopeGoogleTalk)
 	if err != nil {
 		return nil, err
@@ -75,6 +76,7 @@ func NewGoogleCloudPrint(baseURL, robotRefreshToken, userRefreshToken, proxyName
 		robotClient:       robotClient,
 		userClient:        userClient,
 		proxyName:         proxyName,
+		useFcm:            useFcm,
 		jobs:              jobs,
 		downloadSemaphore: lib.NewSemaphore(maxConcurrentDownload),
 	}
@@ -291,6 +293,10 @@ func (gcp *GoogleCloudPrint) Register(printer *lib.Printer) error {
 	sort.Strings(sortedKeys)
 	for _, key := range sortedKeys {
 		form.Add("tag", fmt.Sprintf("%s%s=%s", gcpTagPrefix, key, printer.Tags[key]))
+	}
+
+	if gcp.useFcm {
+		form.Add("tag", fmt.Sprintf("%s%s=%s", gcpTagPrefix, "fcm", "true"))
 	}
 
 	responseBody, _, _, err := postWithRetry(gcp.robotClient, gcp.baseURL+"register", form)
@@ -546,6 +552,24 @@ func (gcp *GoogleCloudPrint) Download(dst io.Writer, url string) error {
 	return nil
 }
 
+// FCM Subscribe.
+func (gcp *GoogleCloudPrint) FcmSubscribe(subscribeUrl string) (interface{}, error) {
+	response, err := getWithRetry(gcp.robotClient, fmt.Sprintf("%s%s", gcp.baseURL, subscribeUrl))
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get Fcm Token: %s", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode == 200 {
+		data, _ := ioutil.ReadAll(response.Body)
+		var f interface{}
+		json.Unmarshal(data, &f)
+		return f, nil
+	} else {
+		return nil, fmt.Errorf("Failed to get Fcm Token: %s", response)
+	}
+}
+
 // Ticket gets a ticket, aka print job options.
 func (gcp *GoogleCloudPrint) Ticket(gcpJobID string) (*cdd.CloudJobTicket, error) {
 	form := url.Values{}
@@ -718,8 +742,13 @@ func (gcp *GoogleCloudPrint) assembleJob(job *Job) (*cdd.CloudJobTicket, string,
 
 	gcp.downloadSemaphore.Acquire()
 	t := time.Now()
+	downloadUrl := job.FileURL
+	if !strings.HasPrefix(downloadUrl, "http") {
+		// test env url need to prefix with http
+		downloadUrl = "http://" + job.FileURL
+	}
 	// Do not check err until semaphore is released and timer is stopped.
-	err = gcp.Download(file, job.FileURL)
+	err = gcp.Download(file, downloadUrl)
 	dt := time.Since(t)
 	gcp.downloadSemaphore.Release()
 	if err != nil {

--- a/lib/config.go
+++ b/lib/config.go
@@ -33,6 +33,11 @@ var (
 		Value: defaultConfigFilename,
 	}
 
+	UseFcm = cli.BoolFlag{
+		Name:  "gcp-use-fcm",
+		Usage: "Receive print notifications from FCM instead of XMPP",
+	}
+
 	// To be populated by something like:
 	// go install -ldflags "-X github.com/google/cloud-print-connector/lib.BuildDate=`date +%Y.%m.%d`"
 	BuildDate = "DEV"
@@ -111,6 +116,9 @@ func (c *Config) commonSparse(context *cli.Context) *Config {
 	if s.GCPBaseURL == DefaultConfig.GCPBaseURL {
 		s.GCPBaseURL = ""
 	}
+	if s.FcmServerBindUrl == DefaultConfig.FcmServerBindUrl {
+		s.FcmServerBindUrl = ""
+	}
 	if s.GCPOAuthClientID == DefaultConfig.GCPOAuthClientID {
 		s.GCPOAuthClientID = ""
 	}
@@ -176,6 +184,9 @@ func (c *Config) commonBackfill(configMap map[string]interface{}) *Config {
 	}
 	if _, exists := configMap["gcp_base_url"]; !exists {
 		b.GCPBaseURL = DefaultConfig.GCPBaseURL
+	}
+	if _, exists := configMap["fcm_server_bind_url"]; !exists {
+		b.FcmServerBindUrl = DefaultConfig.FcmServerBindUrl
 	}
 	if _, exists := configMap["gcp_oauth_client_id"]; !exists {
 		b.GCPOAuthClientID = DefaultConfig.GCPOAuthClientID

--- a/lib/config_unix.go
+++ b/lib/config_unix.go
@@ -45,6 +45,9 @@ type Config struct {
 	// User-chosen name of this proxy. Should be unique per Google user account.
 	ProxyName string `json:"proxy_name,omitempty"`
 
+	// FCM url client should listen on.
+	FcmServerBindUrl string `json:"fcm_server_bind_url,omitempty"`
+
 	// XMPP server FQDN.
 	XMPPServer string `json:"xmpp_server,omitempty"`
 
@@ -160,6 +163,7 @@ var DefaultConfig = Config{
 	XMPPPort:                  443,
 	XMPPPingTimeout:           "5s",
 	XMPPPingInterval:          "2m",
+	FcmServerBindUrl:          "https://fcm-stream.googleapis.com/fcm/connect/bind",
 	GCPBaseURL:                "https://www.google.com/cloudprint/",
 	GCPOAuthClientID:          "539833558011-35iq8btpgas80nrs3o7mv99hm95d4dv6.apps.googleusercontent.com",
 	GCPOAuthClientSecret:      "V9BfPOvdiYuw12hDx5Y5nR0a",

--- a/lib/config_windows.go
+++ b/lib/config_windows.go
@@ -43,6 +43,9 @@ type Config struct {
 	// User-chosen name of this proxy. Should be unique per Google user account.
 	ProxyName string `json:"proxy_name,omitempty"`
 
+	// FCM url client should listen on.
+	FcmServerBindUrl string `json:"fcm_server_bind_url,omitempty"`
+
 	// XMPP server FQDN.
 	XMPPServer string `json:"xmpp_server,omitempty"`
 
@@ -118,6 +121,7 @@ var DefaultConfig = Config{
 	XMPPPort:                  443,
 	XMPPPingTimeout:           "5s",
 	XMPPPingInterval:          "2m",
+	FcmServerBindUrl:          "https://fcm-stream.googleapis.com/fcm/connect/bind",
 	GCPBaseURL:                "https://www.google.com/cloudprint/",
 	GCPOAuthClientID:          "539833558011-35iq8btpgas80nrs3o7mv99hm95d4dv6.apps.googleusercontent.com",
 	GCPOAuthClientSecret:      "V9BfPOvdiYuw12hDx5Y5nR0a",

--- a/notification/notification.go
+++ b/notification/notification.go
@@ -1,0 +1,12 @@
+package notification
+
+type PrinterNotificationType uint8
+type PrinterNotification struct {
+	GCPID string
+	Type  PrinterNotificationType
+}
+
+const (
+	PrinterNewJobs PrinterNotificationType = iota
+	PrinterDelete
+)

--- a/xmpp/internal-xmpp.go
+++ b/xmpp/internal-xmpp.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/google/cloud-print-connector/log"
+	"github.com/google/cloud-print-connector/notification"
 )
 
 const (
@@ -42,7 +43,7 @@ type internalXMPP struct {
 	xmlDecoder *xml.Decoder
 	fullJID    string
 
-	notifications chan<- PrinterNotification
+	notifications chan<- notification.PrinterNotification
 	pongs         chan uint8
 	nextPingID    uint8
 	dead          chan<- struct{}
@@ -53,7 +54,7 @@ type internalXMPP struct {
 // Received XMPP notifications are sent on the notifications channel.
 //
 // If the connection dies unexpectedly, a message is sent on dead.
-func newInternalXMPP(jid, accessToken, proxyName, server string, port uint16, pingTimeout, pingInterval time.Duration, notifications chan<- PrinterNotification, dead chan<- struct{}) (*internalXMPP, error) {
+func newInternalXMPP(jid, accessToken, proxyName, server string, port uint16, pingTimeout, pingInterval time.Duration, notifications chan<- notification.PrinterNotification, dead chan<- struct{}) (*internalXMPP, error) {
 	var user, domain string
 	if parts := strings.SplitN(jid, "@", 2); len(parts) != 2 {
 		return nil, fmt.Errorf("Tried to use invalid XMPP JID: %s", jid)
@@ -188,11 +189,11 @@ func (x *internalXMPP) dispatchIncoming(dying chan<- struct{}) {
 			if strings.ContainsRune(messageDataString, '/') {
 				if strings.HasSuffix(messageDataString, "/delete") {
 					gcpID := strings.TrimSuffix(messageDataString, "/delete")
-					x.notifications <- PrinterNotification{gcpID, PrinterDelete}
+					x.notifications <- notification.PrinterNotification{gcpID, notification.PrinterDelete}
 				}
 				// Ignore other suffixes, like /update_settings.
 			} else {
-				x.notifications <- PrinterNotification{messageDataString, PrinterNewJobs}
+				x.notifications <- notification.PrinterNotification{messageDataString, notification.PrinterNewJobs}
 			}
 
 		} else if startElement.Name.Local == "iq" {

--- a/xmpp/xmpp.go
+++ b/xmpp/xmpp.go
@@ -13,19 +13,10 @@ import (
 	"time"
 
 	"github.com/google/cloud-print-connector/log"
+	"github.com/google/cloud-print-connector/notification"
 )
 
 type PrinterNotificationType uint8
-
-const (
-	PrinterNewJobs PrinterNotificationType = iota
-	PrinterDelete
-)
-
-type PrinterNotification struct {
-	GCPID string
-	Type  PrinterNotificationType
-}
 
 type XMPP struct {
 	jid            string
@@ -36,7 +27,7 @@ type XMPP struct {
 	pingInterval   time.Duration
 	getAccessToken func() (string, error)
 
-	notifications chan<- PrinterNotification
+	notifications chan<- notification.PrinterNotification
 	dead          chan struct{}
 
 	quit chan struct{}
@@ -44,7 +35,7 @@ type XMPP struct {
 	ix *internalXMPP
 }
 
-func NewXMPP(jid, proxyName, server string, port uint16, pingTimeout, pingInterval time.Duration, getAccessToken func() (string, error), notifications chan<- PrinterNotification) (*XMPP, error) {
+func NewXMPP(jid, proxyName, server string, port uint16, pingTimeout, pingInterval time.Duration, getAccessToken func() (string, error), notifications chan<- notification.PrinterNotification) (*XMPP, error) {
 	x := XMPP{
 		jid:            jid,
 		proxyName:      proxyName,

--- a/xmpp/xmpp_test.go
+++ b/xmpp/xmpp_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/cloud-print-connector/notification"
 	"github.com/google/cloud-print-connector/xmpp"
 )
 
@@ -53,7 +54,7 @@ func TestXMPP_proxyauth(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ch := make(chan<- xmpp.PrinterNotification)
+	ch := make(chan<- notification.PrinterNotification)
 	x, err := xmpp.NewXMPP("jid@example.com", "proxyName", strs[0], uint16(port), time.Minute, time.Minute, func() (string, error) {
 		return "accessToken", nil
 	}, ch)
@@ -85,7 +86,7 @@ func testXMPP_reconnect(t *testing.T) {
 		http.DefaultTransport = orig
 	}()
 
-	ch := make(chan<- xmpp.PrinterNotification)
+	ch := make(chan<- notification.PrinterNotification)
 	x, err := xmpp.NewXMPP("jid@example.com", "proxyName", "127.0.0.1", ts.port, time.Minute, time.Minute, func() (string, error) {
 		return "accessToken", nil
 	}, ch)
@@ -113,7 +114,7 @@ func TestXMPP_ping(t *testing.T) {
 		http.DefaultTransport = orig
 	}()
 
-	ch := make(chan<- xmpp.PrinterNotification)
+	ch := make(chan<- notification.PrinterNotification)
 	x, err := xmpp.NewXMPP("jid@example.com", "proxyName", "127.0.0.1", ts.port, time.Second, time.Second, func() (string, error) {
 		return "accessToken", nil
 	}, ch)
@@ -145,7 +146,7 @@ func testXMPP_pingtimeout(t *testing.T) {
 		http.DefaultTransport = orig
 	}()
 
-	ch := make(chan<- xmpp.PrinterNotification)
+	ch := make(chan<- notification.PrinterNotification)
 	x, err := xmpp.NewXMPP("jid@example.com", "proxyName", "127.0.0.1", ts.port, time.Millisecond, time.Millisecond, func() (string, error) {
 		return "accessToken", nil
 	}, ch)


### PR DESCRIPTION
Enables connector to receive both xmpp and FCM notifications from Google Cloud Print server.

The switch happens only if gcp-use-fcm flag is passed during connector start up else the CL is noop.

Test Added.

This pull request is squash of 
https://github.com/google/cloud-print-connector/pull/373/commits