### PR TITLE
Add capability to switch b/w XMPP and FCM.

### DIFF
--- a/gcp-cups-connector/gcp-cups-connector.go
+++ b/gcp-cups-connector/gcp-cups-connector.go
@@ -200,7 +200,7 @@ func connector(context *cli.Context) error {
 	}
 	pm, err := manager.NewPrinterManager(c, g, priv, nativePrinterPollInterval,
 		config.NativeJobQueueSize, *config.CUPSJobFullUsername, config.ShareScope,
-		jobs, notifications)
+		jobs, notifications, useFcm)
 	if err != nil {
 		log.Fatal(err)
 		return cli.NewExitError(err.Error(), 1)

--- a/gcp-windows-connector/gcp-windows-connector.go
+++ b/gcp-windows-connector/gcp-windows-connector.go
@@ -177,7 +177,8 @@ func (service *service) Execute(args []string, r <-chan svc.ChangeRequest, s cha
 		return false, 1
 	}
 	pm, err := manager.NewPrinterManager(ws, g, nil, nativePrinterPollInterval,
-		config.NativeJobQueueSize, *config.CUPSJobFullUsername, config.ShareScope, jobs, notifications)
+		config.NativeJobQueueSize, *config.CUPSJobFullUsername, config.ShareScope, jobs, notifications,
+		useFcm)
 	if err != nil {
 		log.Fatal(err)
 		return false, 1

--- a/gcp/gcp.go
+++ b/gcp/gcp.go
@@ -567,7 +567,7 @@ func (gcp *GoogleCloudPrint) Download(dst io.Writer, url string) error {
 func (gcp *GoogleCloudPrint) FcmSubscribe(subscribeUrl string) (interface{}, error) {
 	response, err := getWithRetry(gcp.robotClient, fmt.Sprintf("%s%s", gcp.baseURL, subscribeUrl))
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get Fcm Token: %s", err)
+		return nil, fmt.Errorf("failed to get Fcm Token: %s", err)
 	}
 	defer response.Body.Close()
 
@@ -577,7 +577,7 @@ func (gcp *GoogleCloudPrint) FcmSubscribe(subscribeUrl string) (interface{}, err
 		json.Unmarshal(data, &f)
 		return f, nil
 	} else {
-		return nil, fmt.Errorf("Failed to get Fcm Token: %s", response)
+		return nil, fmt.Errorf("failed to get Fcm Token: %d", response.StatusCode)
 	}
 }
 

--- a/lib/printer.go
+++ b/lib/printer.go
@@ -22,25 +22,26 @@ type DuplexVendorMap map[cdd.DuplexType]string
 
 // CUPS: cups_dest_t; GCP: /register and /update interfaces
 type Printer struct {
-	GCPID              string                         //                                    GCP: printerid (GCP key)
-	Name               string                         // CUPS: cups_dest_t.name (CUPS key); GCP: name field
-	DefaultDisplayName string                         // CUPS: printer-info;                GCP: default_display_name field
-	UUID               string                         // CUPS: printer-uuid;                GCP: uuid field
-	Manufacturer       string                         // CUPS: PPD;                         GCP: manufacturer field
-	Model              string                         // CUPS: PPD;                         GCP: model field
-	GCPVersion         string                         //                                    GCP: gcpVersion field
-	SetupURL           string                         //                                    GCP: setup_url field
-	SupportURL         string                         //                                    GCP: support_url field
-	UpdateURL          string                         //                                    GCP: update_url field
-	ConnectorVersion   string                         //                                    GCP: firmware field
-	State              *cdd.PrinterStateSection       // CUPS: various;                     GCP: semantic_state field
-	Description        *cdd.PrinterDescriptionSection // CUPS: translated PPD;              GCP: capabilities field
-	CapsHash           string                         // CUPS: hash of PPD;                 GCP: capsHash field
-	Tags               map[string]string              // CUPS: all printer attributes;      GCP: repeated tag field
-	DuplexMap          DuplexVendorMap                // CUPS: PPD;
-	NativeJobSemaphore *Semaphore
-	QuotaEnabled       bool
-	DailyQuota         int
+	GCPID               string                         //                                    GCP: printerid (GCP key)
+	Name                string                         // CUPS: cups_dest_t.name (CUPS key); GCP: name field
+	DefaultDisplayName  string                         // CUPS: printer-info;                GCP: default_display_name field
+	UUID                string                         // CUPS: printer-uuid;                GCP: uuid field
+	Manufacturer        string                         // CUPS: PPD;                         GCP: manufacturer field
+	Model               string                         // CUPS: PPD;                         GCP: model field
+	GCPVersion          string                         //                                    GCP: gcpVersion field
+	SetupURL            string                         //                                    GCP: setup_url field
+	SupportURL          string                         //                                    GCP: support_url field
+	UpdateURL           string                         //                                    GCP: update_url field
+	ConnectorVersion    string                         //                                    GCP: firmware field
+	State               *cdd.PrinterStateSection       // CUPS: various;                     GCP: semantic_state field
+	Description         *cdd.PrinterDescriptionSection // CUPS: translated PPD;              GCP: capabilities field
+	CapsHash            string                         // CUPS: hash of PPD;                 GCP: capsHash field
+	Tags                map[string]string              // CUPS: all printer attributes;      GCP: repeated tag field
+	DuplexMap           DuplexVendorMap                // CUPS: PPD;
+	NativeJobSemaphore  *Semaphore
+	QuotaEnabled        bool
+	DailyQuota          int
+	NotificationChannel string
 }
 
 var rDeviceURIHostname *regexp.Regexp = regexp.MustCompile(
@@ -75,21 +76,22 @@ type PrinterDiff struct {
 	Operation PrinterDiffOperation
 	Printer   Printer
 
-	DefaultDisplayNameChanged bool
-	ManufacturerChanged       bool
-	ModelChanged              bool
-	GCPVersionChanged         bool
-	SetupURLChanged           bool
-	SupportURLChanged         bool
-	UpdateURLChanged          bool
-	ConnectorVersionChanged   bool
-	StateChanged              bool
-	DescriptionChanged        bool
-	CapsHashChanged           bool
-	TagsChanged               bool
-	DuplexMapChanged          bool
-	QuotaEnabledChanged       bool
-	DailyQuotaChanged         bool
+	DefaultDisplayNameChanged  bool
+	ManufacturerChanged        bool
+	ModelChanged               bool
+	GCPVersionChanged          bool
+	SetupURLChanged            bool
+	SupportURLChanged          bool
+	UpdateURLChanged           bool
+	ConnectorVersionChanged    bool
+	StateChanged               bool
+	DescriptionChanged         bool
+	CapsHashChanged            bool
+	TagsChanged                bool
+	DuplexMapChanged           bool
+	QuotaEnabledChanged        bool
+	DailyQuotaChanged          bool
+	NotificationChannelChanged bool
 }
 
 func printerSliceToMapByName(s []Printer) map[string]Printer {
@@ -219,11 +221,16 @@ func diffPrinter(pn, pg *Printer) PrinterDiff {
 		d.DailyQuotaChanged = true
 	}
 
+	if pg.NotificationChannel != pn.NotificationChannel {
+		d.NotificationChannelChanged = true
+	}
+
 	if d.DefaultDisplayNameChanged || d.ManufacturerChanged || d.ModelChanged ||
-		d.GCPVersionChanged || d.SetupURLChanged || d.SupportURLChanged ||
-		d.UpdateURLChanged || d.ConnectorVersionChanged || d.StateChanged ||
-		d.DescriptionChanged || d.CapsHashChanged || d.TagsChanged ||
-		d.DuplexMapChanged || d.QuotaEnabledChanged || d.DailyQuotaChanged {
+			d.GCPVersionChanged || d.SetupURLChanged || d.SupportURLChanged ||
+			d.UpdateURLChanged || d.ConnectorVersionChanged || d.StateChanged ||
+			d.DescriptionChanged || d.CapsHashChanged || d.TagsChanged ||
+			d.DuplexMapChanged || d.QuotaEnabledChanged || d.DailyQuotaChanged ||
+			d.NotificationChannelChanged {
 		return d
 	}
 


### PR DESCRIPTION
The current CL enables connector to be able to switch printer notification channel b/w XMPP and FCM

Fcm channel is enabled if fcm flag is passed during connector start up , else connector falls back to XMPP channel.

Gcp will migrate printers b/w FCM and XMPP accordingly.