### PR TITLE
Move enable fcm notifications flag to config file

### DIFF
--- a/gcp-cups-connector/gcp-cups-connector.go
+++ b/gcp-cups-connector/gcp-cups-connector.go
@@ -39,7 +39,6 @@ func main() {
 	app.Version = lib.BuildDate
 	app.Flags = []cli.Flag{
 		lib.ConfigFilenameFlag,
-		lib.UseFcm,
 		cli.BoolFlag{
 			Name:  "log-to-console",
 			Usage: "Log to STDERR, in addition to configured logging",
@@ -57,7 +56,7 @@ func connector(context *cli.Context) error {
 
 	logToJournal := *config.LogToJournal && journal.Enabled()
 	logToConsole := context.Bool("log-to-console")
-	useFcm := context.Bool("gcp-use-fcm")
+	useFcm := config.FcmNotificationsEnable
 
 	if logToJournal {
 		log.SetJournalEnabled(true)

--- a/gcp-windows-connector/gcp-windows-connector.go
+++ b/gcp-windows-connector/gcp-windows-connector.go
@@ -34,7 +34,6 @@ func main() {
 	app.Version = lib.BuildDate
 	app.Flags = []cli.Flag{
 		lib.ConfigFilenameFlag,
-		lib.UseFcm,
 	}
 	app.Action = runService
 	app.Run(os.Args)
@@ -76,7 +75,7 @@ func runService(context *cli.Context) error {
 }
 
 func (service *service) Execute(args []string, r <-chan svc.ChangeRequest, s chan<- svc.Status) (bool, uint32) {
-	useFcm := service.context.Bool("gcp-use-fcm")
+	useFcm := context.FcmNotificationsEnable
 	if service.interactive {
 		if err := log.Start(true); err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to start event log: %s\n", err)

--- a/lib/config.go
+++ b/lib/config.go
@@ -33,11 +33,6 @@ var (
 		Value: defaultConfigFilename,
 	}
 
-	UseFcm = cli.BoolFlag{
-		Name:  "gcp-use-fcm",
-		Usage: "Receive print notifications from FCM instead of XMPP",
-	}
-
 	// To be populated by something like:
 	// go install -ldflags "-X github.com/google/cloud-print-connector/lib.BuildDate=`date +%Y.%m.%d`"
 	BuildDate = "DEV"
@@ -229,6 +224,9 @@ func (c *Config) commonBackfill(configMap map[string]interface{}) *Config {
 	}
 	if _, exists := configMap["cloud_printing_enable"]; !exists {
 		b.CloudPrintingEnable = DefaultConfig.CloudPrintingEnable
+	}
+	if _, exists := configMap["fcm_notifications_enable"]; !exists {
+		b.FcmNotificationsEnable = DefaultConfig.FcmNotificationsEnable
 	}
 	if _, exists := configMap["log_level"]; !exists {
 		b.LogLevel = DefaultConfig.LogLevel

--- a/lib/config_unix.go
+++ b/lib/config_unix.go
@@ -30,6 +30,9 @@ type Config struct {
 	// Enable cloud discovery and printing.
 	CloudPrintingEnable bool `json:"cloud_printing_enable"`
 
+	// Enable fcm notifications instead of xmpp notifications.
+	FcmNotificationsEnable bool `json:"fcm_notifications_enable"`
+
 	// Associated with root account. XMPP credential.
 	XMPPJID string `json:"xmpp_jid,omitempty"`
 
@@ -156,8 +159,9 @@ type Config struct {
 // Omitted Config fields are omitted on purpose; they are unique per
 // connector instance.
 var DefaultConfig = Config{
-	LocalPrintingEnable: true,
-	CloudPrintingEnable: false,
+	LocalPrintingEnable:    true,
+	CloudPrintingEnable:    false,
+	FcmNotificationsEnable: false,
 
 	XMPPServer:                "talk.google.com",
 	XMPPPort:                  443,

--- a/lib/config_windows.go
+++ b/lib/config_windows.go
@@ -28,6 +28,9 @@ type Config struct {
 	// Enable cloud discovery and printing.
 	CloudPrintingEnable bool `json:"cloud_printing_enable"`
 
+	// Enable fcm notifications instead of xmpp notifications.
+	FcmNotificationsEnable bool `json:"fcm_notifications_enable"`
+
 	// Associated with root account. XMPP credential.
 	XMPPJID string `json:"xmpp_jid,omitempty"`
 
@@ -140,10 +143,11 @@ var DefaultConfig = Config{
 		"Microsoft XPS Document Writer",
 		"Google Cloud Printer",
 	},
-	PrinterWhitelist:    []string{},
-	LocalPrintingEnable: true,
-	CloudPrintingEnable: false,
-	LogLevel:            "INFO",
+	PrinterWhitelist:       []string{},
+	LocalPrintingEnable:    true,
+	CloudPrintingEnable:    false,
+	FcmNotificationsEnable: false,
+	LogLevel:               "INFO",
 
 	LocalPortLow:  26000,
 	LocalPortHigh: 26999,


### PR DESCRIPTION
This change will simplify enabling fcm notifications on windows connector.
Includes minor reformatting changes.