### PR TITLE
Fixes Build Failure (see #395)

### DIFF
--- a/gcp-connector-util/init.go
+++ b/gcp-connector-util/init.go
@@ -414,7 +414,7 @@ func initConfigFile(context *cli.Context) error {
 		if context.IsSet("proxy-name") {
 			proxyName = context.String("proxy-name")
 		} else {
-			proxyName = uuid.NewV4().String()
+			proxyName = uuid.Must(uuid.NewV4()).String()
 		}
 
 		var userClient *http.Client


### PR DESCRIPTION
The uuid.NewV4() function apparently sends back multiple values (UUID and err). Upon looking at the uuid.go code I noticed that there was a Must() function that is supposed to wrap functions like NewV4(). I have added the wrapper and now the gcp-connector-util appears to compile correctly.

As a side note, I know next to nothing about golang, so somebody should definitely make sure this is doing what is expected and not simply making the compiler happy.