### PR TITLE
Don't delete printers on PPD Errors (Issue #366)

### DIFF
--- a/cups/cups.h
+++ b/cups/cups.h
@@ -49,6 +49,7 @@ http_t *httpConnect2(const char *host, int port, http_addrlist_t *addrlist, int 
 # define HTTP_ENCRYPTION_ALWAYS       HTTP_ENCRYPT_ALWAYS
 # define HTTP_STATUS_OK               HTTP_OK
 # define HTTP_STATUS_NOT_MODIFIED     HTTP_NOT_MODIFIED
+# define HTTP_STATUS_NOT_FOUND        HTTP_NOT_FOUND
 # define IPP_OP_CUPS_GET_PRINTERS     CUPS_GET_PRINTERS
 # define IPP_OP_GET_JOB_ATTRIBUTES    IPP_GET_JOB_ATTRIBUTES
 # define IPP_STATUS_OK                IPP_OK


### PR DESCRIPTION
I was recently bitten by Issue #366 after upgrading to the latest version (after being on a very old version.)

This PR implements a mostly similar fix as mentioned in that issue.

I wouldn't call this the best fix, as it treats unknown errors when fetching a PPD as a cache hit, but I think this is far better than the current alternative of just returning an error and causing the printer (with all sharing information) to be deleted.

An eventual ideal implementation would have the ability to detect errors and mark printers as offline instead of the white/black keep/delete approach. I didn't delve too far into the code, but it doesn't look like there's any mechanisms like that right now.

I hope you'll still accept this PR in the meantime, though, as the current code can be very destructive.