### PR TITLE
reduce level info > debug for sync messages

### DIFF
--- a/manager/printermanager.go
+++ b/manager/printermanager.go
@@ -162,7 +162,7 @@ func (pm *PrinterManager) syncPrintersPeriodically(interval time.Duration) {
 }
 
 func (pm *PrinterManager) SyncPrinters(ignorePrivet bool) error {
-	log.Info("Synchronizing printers, stand by")
+	log.Debug("Synchronizing printers, stand by")
 
 	// Get current snapshot of native printers.
 	nativePrinters, err := pm.native.GetPrinters()
@@ -190,7 +190,7 @@ func (pm *PrinterManager) SyncPrinters(ignorePrivet bool) error {
 	// Compare the snapshot to what we know currently.
 	diffs := lib.DiffPrinters(nativePrinters, pm.printers.GetAll())
 	if diffs == nil {
-		log.Infof("Printers are already in sync; there are %d", len(nativePrinters))
+		log.Debugf("Printers are already in sync; there are %d", len(nativePrinters))
 		return nil
 	}
 
@@ -209,7 +209,7 @@ func (pm *PrinterManager) SyncPrinters(ignorePrivet bool) error {
 
 	// Update what we know.
 	pm.printers.Refresh(currentPrinters)
-	log.Infof("Finished synchronizing %d printers", len(currentPrinters))
+	log.Debugf("Finished synchronizing %d printers", len(currentPrinters))
 
 	return nil
 }


### PR DESCRIPTION
3 printer sync messages get logged constantly at INFO level spamming log
files and Windows event viewer. Reduce regular sync messages to DEBUG to
keep them off by default. Other log entries like printer
add/update/delete are still INFO.