### PR TITLE
Migrate usage of urfave/cli from v1 to v2

### DIFF
--- a/gcp-connector-util/gcp-cups-connector-util.go
+++ b/gcp-connector-util/gcp-cups-connector-util.go
@@ -22,137 +22,138 @@ import (
 	"github.com/urfave/cli"
 )
 
-var commonCommands = []cli.Command{
-	cli.Command{
+var commonCommands = []*cli.Command{
+	&cli.Command{
 		Name:   "delete-all-gcp-printers",
 		Usage:  "Delete all printers associated with this connector",
 		Action: deleteAllGCPPrinters,
 	},
-	cli.Command{
+	&cli.Command{
 		Name:   "backfill-config-file",
 		Usage:  "Add all keys, with default values, to the config file",
 		Action: backfillConfigFile,
 	},
-	cli.Command{
+	&cli.Command{
 		Name:   "sparse-config-file",
 		Usage:  "Remove all keys, with non-default values, from the config file",
 		Action: sparseConfigFile,
 	},
-	cli.Command{
+	&cli.Command{
 		Name:   "delete-gcp-job",
 		Usage:  "Deletes one GCP job",
 		Action: deleteGCPJob,
 		Flags: []cli.Flag{
-			cli.StringFlag{
+			&cli.StringFlag{
 				Name: "job-id",
 			},
 		},
 	},
-	cli.Command{
+	&cli.Command{
 		Name:   "cancel-gcp-job",
 		Usage:  "Cancels one GCP job",
 		Action: cancelGCPJob,
 		Flags: []cli.Flag{
-			cli.StringFlag{
+			&cli.StringFlag{
 				Name: "job-id",
 			},
 		},
 	},
-	cli.Command{
+	&cli.Command{
 		Name:   "delete-all-gcp-printer-jobs",
 		Usage:  "Delete all queued jobs associated with a printer",
 		Action: deleteAllGCPPrinterJobs,
 		Flags: []cli.Flag{
-			cli.StringFlag{
+			&cli.StringFlag{
 				Name: "printer-id",
 			},
 		},
 	},
-	cli.Command{
+	&cli.Command{
 		Name:   "cancel-all-gcp-printer-jobs",
 		Usage:  "Cancels all queued jobs associated with a printer",
 		Action: cancelAllGCPPrinterJobs,
 		Flags: []cli.Flag{
-			cli.StringFlag{
+			&cli.StringFlag{
 				Name: "printer-id",
 			},
 		},
 	},
-	cli.Command{
+	&cli.Command{
 		Name:   "show-gcp-printer-status",
 		Usage:  "Shows the current status of a printer and its jobs",
 		Action: showGCPPrinterStatus,
 		Flags: []cli.Flag{
-			cli.StringFlag{
+			&cli.StringFlag{
 				Name: "printer-id",
 			},
 		},
 	},
-	cli.Command{
+	&cli.Command{
 		Name:   "share-gcp-printer",
 		Usage:  "Shares a printer with user or group",
 		Action: shareGCPPrinter,
 		Flags: []cli.Flag{
-			cli.StringFlag{
+			&cli.StringFlag{
 				Name:  "printer-id",
 				Usage: "Printer to share",
 			},
-			cli.StringFlag{
+			&cli.StringFlag{
 				Name:  "email",
 				Usage: "Group or user to share with",
 			},
-			cli.StringFlag{
+			&cli.StringFlag{
 				Name:  "role",
 				Value: "USER",
 				Usage: "Role granted. user or manager",
 			},
-			cli.BoolTFlag{
+			&cli.BoolFlag{
 				Name:  "skip-notification",
 				Usage: "Skip sending email notice. Defaults to true",
+				DefaultText: "1",
 			},
-			cli.BoolFlag{
+			&cli.BoolFlag{
 				Name:  "public",
 				Usage: "Make the printer public (anyone can print)",
 			},
 		},
 	},
-	cli.Command{
+	&cli.Command{
 		Name:   "unshare-gcp-printer",
 		Usage:  "Removes user or group access to printer",
 		Action: unshareGCPPrinter,
 		Flags: []cli.Flag{
-			cli.StringFlag{
+			&cli.StringFlag{
 				Name:  "printer-id",
 				Usage: "Printer to unshare",
 			},
-			cli.StringFlag{
+			&cli.StringFlag{
 				Name:  "email",
 				Usage: "Group or user to remove",
 			},
-			cli.BoolFlag{
+			&cli.BoolFlag{
 				Name:  "public",
 				Usage: "Remove public printer access",
 			},
 		},
 	},
-	cli.Command{
+	&cli.Command{
 		Name:   "update-gcp-printer",
 		Usage:  "Modifies settings for a printer",
 		Action: updateGCPPrinter,
 		Flags: []cli.Flag{
-			cli.StringFlag{
+			&cli.StringFlag{
 				Name:  "printer-id",
 				Usage: "Printer to update",
 			},
-			cli.BoolFlag{
+			&cli.BoolFlag{
 				Name:  "enable-quota",
 				Usage: "Set a daily per-user quota",
 			},
-			cli.BoolFlag{
+			&cli.BoolFlag{
 				Name:  "disable-quota",
 				Usage: "Disable daily per-user quota",
 			},
-			cli.IntFlag{
+			&cli.IntFlag{
 				Name:  "daily-quota",
 				Usage: "Pages per-user per-day",
 			},

--- a/gcp-connector-util/init.go
+++ b/gcp-connector-util/init.go
@@ -35,116 +35,116 @@ const (
 )
 
 var commonInitFlags = []cli.Flag{
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:  "gcp-oauth-token-poll-url",
 		Usage: "OAuth token poll URL",
 		Value: gcpOAuthTokenPollURL,
 	},
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:  "gcp-base-url",
 		Usage: "GCP base URL",
 		Value: lib.DefaultConfig.GCPBaseURL,
 	},
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:  "gcp-oauth-device-code-url",
 		Usage: "OAuth device code URL",
 		Value: gcpOAuthDeviceCodeURL,
 	},
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:  "gcp-oauth-token-url",
 		Usage: "OAuth token URL",
 		Value: lib.DefaultConfig.GCPOAuthTokenURL,
 	},
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:  "gcp-oauth-auth-url",
 		Usage: "OAuth auth URL",
 		Value: lib.DefaultConfig.GCPOAuthAuthURL,
 	},
-	cli.DurationFlag{
+	&cli.DurationFlag{
 		Name:  "gcp-api-timeout",
 		Usage: "GCP API timeout, for debugging",
 		Value: 30 * time.Second,
 	},
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:  "gcp-oauth-client-id",
 		Usage: "Identifies the CUPS Connector to the Google Cloud Print cloud service",
 		Value: lib.DefaultConfig.GCPOAuthClientID,
 	},
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:  "gcp-oauth-client-secret",
 		Usage: "Goes along with the Client ID. Not actually secret",
 		Value: lib.DefaultConfig.GCPOAuthClientSecret,
 	},
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:  "gcp-user-refresh-token",
 		Usage: "GCP user refresh token, useful when managing many connectors",
 	},
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:  "share-scope",
 		Usage: "Scope (user or group email address) to automatically share printers with",
 	},
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:  "proxy-name",
 		Usage: "Name for this connector instance. Should be unique per Google user account",
 	},
-	cli.IntFlag{
+	&cli.IntFlag{
 		Name:  "xmpp-port",
 		Usage: "XMPP port number",
 		Value: int(lib.DefaultConfig.XMPPPort),
 	},
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:  "xmpp-ping-timeout",
 		Usage: "XMPP ping timeout (give up waiting for ping response after this)",
 		Value: lib.DefaultConfig.XMPPPingTimeout,
 	},
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:  "xmpp-ping-interval",
 		Usage: "XMPP ping interval (ping every this often)",
 		Value: lib.DefaultConfig.XMPPPingInterval,
 	},
-	cli.IntFlag{
+	&cli.IntFlag{
 		Name:  "gcp-max-concurrent-downloads",
 		Usage: "Maximum quantity of PDFs to download concurrently from GCP cloud service",
 		Value: int(lib.DefaultConfig.GCPMaxConcurrentDownloads),
 	},
-	cli.IntFlag{
+	&cli.IntFlag{
 		Name:  "native-job-queue-size",
 		Usage: "Native job queue size",
 		Value: int(lib.DefaultConfig.NativeJobQueueSize),
 	},
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:  "native-printer-poll-interval",
 		Usage: "Interval, in seconds, between native printer state polls",
 		Value: lib.DefaultConfig.NativePrinterPollInterval,
 	},
-	cli.BoolFlag{
+	&cli.BoolFlag{
 		Name:  "prefix-job-id-to-job-title",
 		Usage: "Whether to add the job ID to the beginning of the job title",
 	},
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:  "display-name-prefix",
 		Usage: "Prefix to add to GCP printer's display name",
 		Value: lib.DefaultConfig.DisplayNamePrefix,
 	},
-	cli.BoolFlag{
+	&cli.BoolFlag{
 		Name:  "local-printing-enable",
 		Usage: "Enable local discovery and printing (aka GCP 2.0 or Privet)",
 	},
-	cli.BoolFlag{
+	&cli.BoolFlag{
 		Name:  "cloud-printing-enable",
 		Usage: "Enable cloud discovery and printing",
 	},
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:  "log-level",
 		Usage: "Minimum event severity to log: FATAL, ERROR, WARNING, INFO, DEBUG",
 		Value: lib.DefaultConfig.LogLevel,
 	},
-	cli.IntFlag{
+	&cli.IntFlag{
 		Name:  "local-port-low",
 		Usage: "Local HTTP API server port range, low",
 		Value: int(lib.DefaultConfig.LocalPortLow),
 	},
-	cli.IntFlag{
+	&cli.IntFlag{
 		Name:  "local-port-high",
 		Usage: "Local HTTP API server port range, high",
 		Value: int(lib.DefaultConfig.LocalPortHigh),

--- a/gcp-connector-util/main_unix.go
+++ b/gcp-connector-util/main_unix.go
@@ -17,73 +17,76 @@ import (
 )
 
 var unixInitFlags = []cli.Flag{
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:  "log-file-name",
 		Usage: "Log file name, full path",
 		Value: lib.DefaultConfig.LogFileName,
 	},
-	cli.IntFlag{
+	&cli.IntFlag{
 		Name:  "log-file-max-megabytes",
 		Usage: "Log file max size, in megabytes",
 		Value: int(lib.DefaultConfig.LogFileMaxMegabytes),
 	},
-	cli.IntFlag{
+	&cli.IntFlag{
 		Name:  "log-max-files",
 		Usage: "Maximum log file quantity before rollover",
 		Value: int(lib.DefaultConfig.LogMaxFiles),
 	},
-	cli.BoolFlag{
+	&cli.BoolFlag{
 		Name:  "log-to-journal",
 		Usage: "Log to the systemd journal (if available) instead of to log-file-name",
 	},
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:  "monitor-socket-filename",
 		Usage: "Filename of unix socket for connector-check to talk to connector",
 		Value: lib.DefaultConfig.MonitorSocketFilename,
 	},
-	cli.IntFlag{
+	&cli.IntFlag{
 		Name:  "cups-max-connections",
 		Usage: "Max connections to CUPS server",
 		Value: int(lib.DefaultConfig.CUPSMaxConnections),
 	},
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:  "cups-connect-timeout",
 		Usage: "CUPS timeout for opening a new connection",
 		Value: lib.DefaultConfig.CUPSConnectTimeout,
 	},
-	cli.BoolFlag{
+	&cli.BoolFlag{
 		Name:  "cups-job-full-username",
 		Usage: "Whether to use the full username (joe@example.com) in CUPS jobs",
 	},
-	cli.BoolTFlag{
+	&cli.BoolFlag{
 		Name:  "cups-ignore-raw-printers",
 		Usage: "Whether to ignore CUPS raw printers",
+		DefaultText: "1",
 	},
-	cli.BoolTFlag{
+	&cli.BoolFlag{
 		Name:  "cups-ignore-class-printers",
 		Usage: "Whether to ignore CUPS class printers",
+		DefaultText: "1",
 	},
-	cli.BoolTFlag{
+	&cli.BoolFlag{
 		Name:  "copy-printer-info-to-display-name",
 		Usage: "Whether to copy the CUPS printer's printer-info attribute to the GCP printer's defaultDisplayName",
+		DefaultText: "1",
 	},
 }
 
-var unixCommands = []cli.Command{
-	cli.Command{
+var unixCommands = []*cli.Command{
+	&cli.Command{
 		Name:      "init",
-		ShortName: "i",
+		Aliases:   []string{"i"},
 		Usage:     "Creates a config file",
 		Action:    initConfigFile,
 		Flags:     append(commonInitFlags, unixInitFlags...),
 	},
-	cli.Command{
+	&cli.Command{
 		Name:      "monitor",
-		ShortName: "m",
+		Aliases: []string{"m"},
 		Usage:     "Read stats from a running connector",
 		Action:    monitorConnector,
 		Flags: []cli.Flag{
-			cli.DurationFlag{
+			&cli.DurationFlag{
 				Name:  "monitor-timeout",
 				Usage: "wait for a monitor response no more than this long",
 				Value: 10 * time.Second,
@@ -98,7 +101,7 @@ func main() {
 	app.Usage = lib.ConnectorName + " for CUPS utility tools"
 	app.Version = lib.BuildDate
 	app.Flags = []cli.Flag{
-		lib.ConfigFilenameFlag,
+		&lib.ConfigFilenameFlag,
 	}
 	app.Commands = append(unixCommands, commonCommands...)
 

--- a/gcp-connector-util/main_windows.go
+++ b/gcp-connector-util/main_windows.go
@@ -20,40 +20,40 @@ import (
 	"golang.org/x/sys/windows/svc/mgr"
 )
 
-var windowsCommands = []cli.Command{
-	cli.Command{
+var windowsCommands = []*cli.Command{
+	&cli.Command{
 		Name:      "init",
-		ShortName: "i",
+		Aliases:   []string{"i"},
 		Usage:     "Create a config file",
 		Action:    initConfigFile,
 		Flags:     commonInitFlags,
 	},
-	cli.Command{
+	&cli.Command{
 		Name:   "install-event-log",
 		Usage:  "Install registry entries for the event log",
 		Action: installEventLog,
 	},
-	cli.Command{
+	&cli.Command{
 		Name:   "remove-event-log",
 		Usage:  "Remove registry entries for the event log",
 		Action: removeEventLog,
 	},
-	cli.Command{
+	&cli.Command{
 		Name:   "create-service",
 		Usage:  "Create a service in the local service control manager",
 		Action: createService,
 	},
-	cli.Command{
+	&cli.Command{
 		Name:   "delete-service",
 		Usage:  "Delete an existing service in the local service control manager",
 		Action: deleteService,
 	},
-	cli.Command{
+	&cli.Command{
 		Name:   "start-service",
 		Usage:  "Start the service in the local service control manager",
 		Action: startService,
 	},
-	cli.Command{
+	&cli.Command{
 		Name:   "stop-service",
 		Usage:  "Stop the service in the local service control manager",
 		Action: stopService,
@@ -178,7 +178,7 @@ func main() {
 	app.Usage = lib.ConnectorName + " for Windows utility tools"
 	app.Version = lib.BuildDate
 	app.Flags = []cli.Flag{
-		lib.ConfigFilenameFlag,
+		&lib.ConfigFilenameFlag,
 	}
 	app.Commands = append(windowsCommands, commonCommands...)
 

--- a/gcp-cups-connector/gcp-cups-connector.go
+++ b/gcp-cups-connector/gcp-cups-connector.go
@@ -38,8 +38,8 @@ func main() {
 	app.Usage = lib.ConnectorName + " for CUPS"
 	app.Version = lib.BuildDate
 	app.Flags = []cli.Flag{
-		lib.ConfigFilenameFlag,
-		cli.BoolFlag{
+		&lib.ConfigFilenameFlag,
+		&cli.BoolFlag{
 			Name:  "log-to-console",
 			Usage: "Log to STDERR, in addition to configured logging",
 		},

--- a/gcp-windows-connector/gcp-windows-connector.go
+++ b/gcp-windows-connector/gcp-windows-connector.go
@@ -33,7 +33,7 @@ func main() {
 	app.Usage = lib.ConnectorName + " for Windows"
 	app.Version = lib.BuildDate
 	app.Flags = []cli.Flag{
-		lib.ConfigFilenameFlag,
+		&lib.ConfigFilenameFlag,
 	}
 	app.Action = runService
 	app.Run(os.Args)

--- a/lib/config_unix.go
+++ b/lib/config_unix.go
@@ -232,7 +232,7 @@ var DefaultConfig = Config{
 // If the ConfigFilename exists in a valid XDG path, then it is returned.
 // If neither of those exist, the (relative or absolute) ConfigFilename is returned.
 func getConfigFilename(context *cli.Context) (string, bool) {
-	cf := context.GlobalString("config-filename")
+	cf := context.String("config-filename")
 
 	if filepath.IsAbs(cf) {
 		// Absolute path specified; user knows what they want.

--- a/lib/config_windows.go
+++ b/lib/config_windows.go
@@ -159,7 +159,7 @@ var DefaultConfig = Config{
 // If the ConfigFilename exists, then it is returned as an absolute path.
 // If neither of those exist, the absolute ConfigFilename is returned.
 func getConfigFilename(context *cli.Context) (string, bool) {
-	cf := context.GlobalString("config-filename")
+	cf := context.String("config-filename")
 
 	if filepath.IsAbs(cf) {
 		// Absolute path specified; user knows what they want.


### PR DESCRIPTION
This PR fixes fixes #466 

This applies necessary changes to compile for the latest version of the urfave/cli dependency.