### PR TITLE
Fix/Workaround FTBFS issues: #476

### DIFF
--- a/cups/cups-private.h
+++ b/cups/cups-private.h
@@ -1,0 +1,94 @@
+#ifndef _CUPS_IPP_PRIVATE_H_
+#ifndef CUPS_CUPS_PRIVATE_H_
+
+#define CUPS_CUPS_PRIVATE_H_
+
+/*
+ * https://bugs.launchpad.net/bugs/1859685
+ *
+ * This header is a workaround for LP: #1859685 while the cloud-print-connector
+ * doesn't change its implementation to use the correct functions now that cups
+ * has deactivated the _IPP_PRIVATE_STRUCTURES workaround.
+ *
+ * This file contains parts of ipp-private.h from cups v2.3.1-7-g1f2a315c2
+ */
+
+typedef union _ipp_request_u
+{
+	struct
+	{
+		ipp_uchar_t version[2];
+		int op_status;
+		int request_id;
+	} any;
+	struct
+	{
+		ipp_uchar_t version[2];
+		ipp_op_t operation_id;
+		int request_id;
+	} op;
+	struct
+	{
+		ipp_uchar_t version[2];
+		ipp_status_t status_code;
+		int request_id;
+	} status;
+	struct
+	{
+		ipp_uchar_t version[2];
+		ipp_status_t status_code;
+		int request_id;
+	} event;
+} _ipp_request_t;
+
+typedef union _ipp_value_u
+{
+	int integer;
+	char boolean;
+	ipp_uchar_t date[11];
+	struct
+	{
+		int xres, yres;
+		ipp_res_t units;
+	} resolution;
+	struct
+	{
+		int lower, upper;
+	} range;
+	struct
+	{
+		char *language;
+		char *text;
+	} string;
+	struct
+	{
+		int length;
+		void *data;
+	} unknown;
+	ipp_t *collection;
+} _ipp_value_t;
+
+struct _ipp_attribute_s
+{
+	ipp_attribute_t *next;
+	ipp_tag_t group_tag, value_tag;
+	char *name;
+	int num_values;
+	_ipp_value_t values[1];
+};
+
+struct _ipp_s
+{
+	ipp_state_t state;
+	_ipp_request_t request;
+	ipp_attribute_t *attrs;
+	ipp_attribute_t *last;
+	ipp_attribute_t *current;
+	ipp_tag_t curtag;
+	ipp_attribute_t *prev;
+	int use;
+	int atend, curindex;
+};
+
+#endif /* CUPS_CUPS_PRIVATE_H_ */
+#endif /* _CUPS_IPP_PRIVATE_H_ */

--- a/cups/cups.h
+++ b/cups/cups.h
@@ -19,6 +19,9 @@ https://developers.google.com/open-source/licenses/bsd
 #include <sys/utsname.h> // uname
 #include <time.h>        // time_t
 
+/* https://bugs.launchpad.net/bugs/1859685 */
+#include "cups-private.h"
+
 extern const char
 	*JOB_STATE,
 	*JOB_MEDIA_SHEETS_COMPLETED,

--- a/gcp-connector-util/gcp-cups-connector-util.go
+++ b/gcp-connector-util/gcp-cups-connector-util.go
@@ -109,7 +109,6 @@ var commonCommands = []cli.Command{
 			&cli.BoolFlag{
 				Name:  "skip-notification",
 				Usage: "Skip sending email notice. Defaults to true",
-				DefaultText: "1",
 			},
 			&cli.BoolFlag{
 				Name:  "public",

--- a/gcp-connector-util/gcp-cups-connector-util.go
+++ b/gcp-connector-util/gcp-cups-connector-util.go
@@ -22,23 +22,23 @@ import (
 	"github.com/urfave/cli"
 )
 
-var commonCommands = []*cli.Command{
-	&cli.Command{
+var commonCommands = []cli.Command{
+	cli.Command{
 		Name:   "delete-all-gcp-printers",
 		Usage:  "Delete all printers associated with this connector",
 		Action: deleteAllGCPPrinters,
 	},
-	&cli.Command{
+	cli.Command{
 		Name:   "backfill-config-file",
 		Usage:  "Add all keys, with default values, to the config file",
 		Action: backfillConfigFile,
 	},
-	&cli.Command{
+	cli.Command{
 		Name:   "sparse-config-file",
 		Usage:  "Remove all keys, with non-default values, from the config file",
 		Action: sparseConfigFile,
 	},
-	&cli.Command{
+	cli.Command{
 		Name:   "delete-gcp-job",
 		Usage:  "Deletes one GCP job",
 		Action: deleteGCPJob,
@@ -48,7 +48,7 @@ var commonCommands = []*cli.Command{
 			},
 		},
 	},
-	&cli.Command{
+	cli.Command{
 		Name:   "cancel-gcp-job",
 		Usage:  "Cancels one GCP job",
 		Action: cancelGCPJob,
@@ -58,7 +58,7 @@ var commonCommands = []*cli.Command{
 			},
 		},
 	},
-	&cli.Command{
+	cli.Command{
 		Name:   "delete-all-gcp-printer-jobs",
 		Usage:  "Delete all queued jobs associated with a printer",
 		Action: deleteAllGCPPrinterJobs,
@@ -68,7 +68,7 @@ var commonCommands = []*cli.Command{
 			},
 		},
 	},
-	&cli.Command{
+	cli.Command{
 		Name:   "cancel-all-gcp-printer-jobs",
 		Usage:  "Cancels all queued jobs associated with a printer",
 		Action: cancelAllGCPPrinterJobs,
@@ -78,7 +78,7 @@ var commonCommands = []*cli.Command{
 			},
 		},
 	},
-	&cli.Command{
+	cli.Command{
 		Name:   "show-gcp-printer-status",
 		Usage:  "Shows the current status of a printer and its jobs",
 		Action: showGCPPrinterStatus,
@@ -88,7 +88,7 @@ var commonCommands = []*cli.Command{
 			},
 		},
 	},
-	&cli.Command{
+	cli.Command{
 		Name:   "share-gcp-printer",
 		Usage:  "Shares a printer with user or group",
 		Action: shareGCPPrinter,
@@ -117,7 +117,7 @@ var commonCommands = []*cli.Command{
 			},
 		},
 	},
-	&cli.Command{
+	cli.Command{
 		Name:   "unshare-gcp-printer",
 		Usage:  "Removes user or group access to printer",
 		Action: unshareGCPPrinter,
@@ -136,7 +136,7 @@ var commonCommands = []*cli.Command{
 			},
 		},
 	},
-	&cli.Command{
+	cli.Command{
 		Name:   "update-gcp-printer",
 		Usage:  "Modifies settings for a printer",
 		Action: updateGCPPrinter,

--- a/gcp-connector-util/main_unix.go
+++ b/gcp-connector-util/main_unix.go
@@ -58,17 +58,14 @@ var unixInitFlags = []cli.Flag{
 	&cli.BoolFlag{
 		Name:  "cups-ignore-raw-printers",
 		Usage: "Whether to ignore CUPS raw printers",
-		DefaultText: "1",
 	},
 	&cli.BoolFlag{
 		Name:  "cups-ignore-class-printers",
 		Usage: "Whether to ignore CUPS class printers",
-		DefaultText: "1",
 	},
 	&cli.BoolFlag{
 		Name:  "copy-printer-info-to-display-name",
 		Usage: "Whether to copy the CUPS printer's printer-info attribute to the GCP printer's defaultDisplayName",
-		DefaultText: "1",
 	},
 }
 

--- a/gcp-connector-util/main_unix.go
+++ b/gcp-connector-util/main_unix.go
@@ -72,15 +72,15 @@ var unixInitFlags = []cli.Flag{
 	},
 }
 
-var unixCommands = []*cli.Command{
-	&cli.Command{
+var unixCommands = []cli.Command{
+	cli.Command{
 		Name:      "init",
 		Aliases:   []string{"i"},
 		Usage:     "Creates a config file",
 		Action:    initConfigFile,
 		Flags:     append(commonInitFlags, unixInitFlags...),
 	},
-	&cli.Command{
+	cli.Command{
 		Name:      "monitor",
 		Aliases: []string{"m"},
 		Usage:     "Read stats from a running connector",


### PR DESCRIPTION
Close: 476

Hello, this is a quick attempt of fixing FTBFS in Ubuntu:

1) New CUPSs do not provide _IPP_PRIVATE_STRUCTURES feature. Missing IPP internal data should be acquired by using the proper new functions provided by CUPS. 

2) For some reason, cloud-print-connection was FTBFS because of golang-github-codegangsta-cli-dev, complaining about types. (codegangsta-cli-dev hasn't changed from previous working version in Ubuntu).

3) Also, for some reason, golang-github-urfave-cli-dev is having problems with BoolFlag DefaultText field. We have moved from previous working version 1.20.0-1 to 1.22.2-1 in recent Ubuntu.

Of course I don't expect these patches to be accept "as-is", but, if they work, they could be added in the beginning in our binary packages if it proves to solve our dependency issues (among other packages). 